### PR TITLE
chore: release dde-launchpad 0.0.1 as tech preview

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-launchpad (0.0.1) unstable; urgency=medium
+
+  * Initial tag release
+  * Implement basic features that required by the launcher component
+
+ -- Gary Wang <wangzichong@deepin.org>  Mon, 04 Sep 2023 14:03:00 +0800
+
 dde-launchpad (0.0.0) UNRELEASED; urgency=medium
 
   * Initial release

--- a/main.cpp
+++ b/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
     QGuiApplication app(argc, argv);
     QCoreApplication::setOrganizationName("deepin");
     QCoreApplication::setApplicationName("dde-launchpad");
-    QCoreApplication::setApplicationVersion("0.0.0" + QStringLiteral("-technical-preview"));
+    QCoreApplication::setApplicationVersion("0.0.1" + QStringLiteral("-technical-preview"));
     DGuiApplicationHelper::loadTranslator(QStringLiteral("dde-launchpad"), translationDir(), { QLocale() });
     bool isOnlyInstance = DGuiApplicationHelper::setSingleInstance(QStringLiteral("dde-launchpad"));
 


### PR DESCRIPTION
发布 0.0.1 技术预览版

### 已知非缺陷问题：

1. 所有和拖拽相关的功能暂未实现，会在后续版本中增加  
   也因此，暂时无法测试全屏启动器的拖拽后应用分组/抽屉的功能
2. 应用右键菜单中的 “使用代理” 一项无实际效果  
   鉴于新 AM 不会支持相关功能，新的对等功能组件还未就绪，此菜单项仅为展示性质的占位作用，也可考虑隐藏处理
3. 卸载功能暂时依赖旧的 dde-application-manager 提供的 d-bus，若旧的 dde-application-manager 被新的替代则对应功能会无作用  
   当前计划为提供一个新的组件（尚未集成），并在新的组件中暂时提供和旧 dbus 完全一致的兼容接口

### 已知缺陷问题（需与其它项目协作处理，可先提 bug）：

1. 切换到全屏 launcher 后，隐藏 launcher，再从任务栏点击 launcher 图标使其显示，此时 launcher 下方未覆盖 dock 区域，且此时再尝试切换到小 launcher 时会发现小 launcher 也为最大化的尺寸（窗管问题）
2. 小 launcher 无法 tab 切换焦点到左侧的列表项目（dtkdeclarative问题）
3. 全屏 launcher 无法双指侧滑切换到下一屏，但可以侧滑切换到上一屏（qt5 问题）
4. 从全屏 launcher 切换到小 launcher 时，launcher 圆角会消失（可能是窗管或 dtkdeclarative 的问题）

### 测试方式：

通过 `sudo apt install dde-launchpad` 即可安装新的启动器。在开始测试前，请确保未启动过旧的 launcher 或旧的 launcher 已退出（`killall dde-launcher` 即可）。

测试完毕后，希望回退到旧 launcher 时，手动 `sudo apt install dde-launcher` 即可。

### 注意事项：

1. 测试前请更新软件包，请至少确保 dde-kwin，startdde 以及 dtk 均已更新到已集成过的最新版本。
2. 由于安装 dde-launchpad 会替换旧的 dde-launcher，会使得 dde-desktop-environment-\* 依赖不再满足，因而 dde-api-proxy 相关软件包可能会被卸载，可主动手动把 dde-api-proxy 安装回来。这个问题应当在 deepin-tweak 里自动帮用户处理，无需视为 bug。
