### PR TITLE
chore: read and use VERSION from DEB_VERSION_UPSTREAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@
 
 cmake_minimum_required(VERSION 3.7)
 
-project(dde-launchpad)
+if(NOT DEFINED VERSION)
+    set(VERSION 0.0.2)
+endif()
+
+project(dde-launchpad VERSION ${VERSION})
 
 set(CMAKE_CXX_STANDARD 17) # blurhash requires 17, otherwish we can still use 14
 set(CMAKE_AUTOMOC ON)
@@ -83,6 +87,11 @@ add_executable(${BIN_NAME}
     ${DBUS_ADAPTER_FILES}
     ${RESOURCES}
     ${TRANSLATED_FILES}
+)
+
+target_compile_definitions(${BIN_NAME}
+PRIVATE
+    DDE_LAUNCHPAD_VERSION=${CMAKE_PROJECT_VERSION}
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE

--- a/debian/rules
+++ b/debian/rules
@@ -13,3 +13,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
 		dh $@ --parallel
+
+override_dh_auto_configure:
+		dh_auto_configure -- \
+			-DVERSION=$(DEB_VERSION_UPSTREAM)

--- a/main.cpp
+++ b/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
     QGuiApplication app(argc, argv);
     QCoreApplication::setOrganizationName("deepin");
     QCoreApplication::setApplicationName("dde-launchpad");
-    QCoreApplication::setApplicationVersion("0.0.1" + QStringLiteral("-technical-preview"));
+    QCoreApplication::setApplicationVersion(QT_STRINGIFY(DDE_LAUNCHPAD_VERSION) + QStringLiteral("-technical-preview"));
     DGuiApplicationHelper::loadTranslator(QStringLiteral("dde-launchpad"), translationDir(), { QLocale() });
     bool isOnlyInstance = DGuiApplicationHelper::setSingleInstance(QStringLiteral("dde-launchpad"));
 


### PR DESCRIPTION
CI scripts or package maintainer can pass `-DVERSION` to CMake to tell the build system which is the `VERSION` that we need to use.
