### PR TITLE
chore: use DIcon::loadNxPixmap from dtkgui

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,6 @@ Build-Depends:
 # v-- provides qdbusxml2cpp-fix binary
  libdtkcore5-bin,
 # v-- provides DHiDPIHelper
- libdtkwidget-dev,
  libdtkgui-dev,
  libdtkdeclarative-dev,
  libappstreamqt-dev

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 find_package(Qt5 REQUIRED Quick)
-find_package(Dtk REQUIRED COMPONENTS Widget) # for DHiDPIHelper, probably can be replaced later
+find_package(Dtk REQUIRED COMPONENTS Gui) # for DHiDPIHelper, probably can be replaced later
 
 add_library(launcher-utils OBJECT)
 
@@ -18,4 +18,4 @@ PRIVATE
 )
 
 target_include_directories(launcher-utils PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-target_link_libraries(launcher-utils PRIVATE Qt::Core Qt::Gui Qt::Svg Dtk::Widget)
+target_link_libraries(launcher-utils PRIVATE Qt::Core Qt::Gui Qt::Svg Dtk::Gui)

--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -9,12 +9,12 @@
 #include <QStandardPaths>
 #include <QGuiApplication>
 #include <QFile>
-#include <DHiDPIHelper>
+#include <DIcon>
 #include <QFileInfo>
 #include <QSvgRenderer>
 #include <QPainter>
 
-DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 bool IconUtils::getThemeIcon(QPixmap &pixmap, const QString &iconName, const int size)
 {
@@ -55,7 +55,7 @@ bool IconUtils::getThemeIcon(QPixmap &pixmap, const QString &iconName, const int
             if (actualIconName.endsWith(".svg"))
                 pixmap = loadSvg(iconName, qRound(iconSize * ratio));
             else
-                pixmap = DHiDPIHelper::loadNxPixmap(actualIconName);
+                pixmap = DIcon::loadNxPixmap(actualIconName);
 
             if (!pixmap.isNull())
                 break;


### PR DESCRIPTION
鉴于 Arch 的 dtkgui 已足够新，此处改用 dtkgui 的接口。

Log: