### PR TITLE
feat: support build with Qt 6 and Dtk 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,24 @@ set(BIN_NAME dde-launchpad)
 include(FeatureSummary)
 include(GNUInstallDirs)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Gui Concurrent Qml Svg Quick QuickCompiler QuickControls2 LinguistTools)
-find_package(Dtk REQUIRED COMPONENTS Core Gui)
-find_package(AppStreamQt)
+option(PREFER_QT_5 "Prefer to use Qt 5 even if we have Qt 6" ON)
+
+if(PREFER_QT_5)
+    set(QT_NS Qt5)
+    set(DTK_NS Dtk)
+else()
+    set(QT_NS Qt6)
+    set(DTK_NS Dtk6)
+endif()
+
+find_package(QT NAMES ${QT_NS} REQUIRED COMPONENTS Core)
+find_package(${QT_NS} REQUIRED COMPONENTS Core Gui Concurrent Qml Svg Quick QuickControls2 LinguistTools)
+find_package(${DTK_NS} REQUIRED COMPONENTS Core Gui)
+
+if(${QT_VERSION_MAJOR} EQUAL "5")
+    find_package(${QT_NS} REQUIRED COMPONENTS QuickCompiler)
+    find_package(AppStreamQt) # AppStreamQt only support Qt 5 at this moment
+endif()
 
 set_package_properties(AppStreamQt PROPERTIES
     DESCRIPTION "Library that lists Appstream resources"
@@ -80,7 +95,11 @@ qt_create_translation(TRANSLATED_FILES ${QML_FILES} ${SOURCE_FILES} src/models/a
 
 qt_add_dbus_adaptor(DBUS_ADAPTER_FILES dbus/org.deepin.dde.Launcher1.xml launchercontroller.h LauncherController)
 
-qtquick_compiler_add_resources(RESOURCES qml.qrc)
+if(${QT_VERSION_MAJOR} EQUAL "5")
+    qtquick_compiler_add_resources(RESOURCES qml.qrc)
+else()
+    qt_add_resources(RESOURCES qml.qrc) # TODO: should use qt_add_qml_module instead
+endif()
 
 add_executable(${BIN_NAME}
     ${SOURCE_FILES}
@@ -95,11 +114,11 @@ PRIVATE
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
-    Dtk::Core
-    Dtk::Gui
-    Qt5::Qml
-    Qt5::Quick
-    Qt5::QuickControls2
+    ${DTK_NS}::Core
+    ${DTK_NS}::Gui
+    Qt::Qml
+    Qt::Quick
+    Qt::QuickControls2
 
     gio-utils
     launcher-utils

--- a/src/ddeintegration/CMakeLists.txt
+++ b/src/ddeintegration/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-find_package(Dtk REQUIRED COMPONENTS Tools) # for ${DTK_XML2CPP} which provides the path of `qdbusxml2cpp-fix` binary
+find_package(${DTK_NS} REQUIRED COMPONENTS Tools) # for ${DTK_XML2CPP} which provides the path of `qdbusxml2cpp-fix` binary
 
 function(dtk_add_dbus_interface _sources _interface _relativename)
     get_filename_component(_infile ${_interface} ABSOLUTE)
@@ -10,10 +10,19 @@ function(dtk_add_dbus_interface _sources _interface _relativename)
     get_filename_component(_basename ${_relativename} NAME)
     set(_header "${CMAKE_CURRENT_BINARY_DIR}/${_relativename}.h")
     set(_impl   "${CMAKE_CURRENT_BINARY_DIR}/${_relativename}.cpp")
-    if(_basepath)
-        set(_moc "${CMAKE_CURRENT_BINARY_DIR}/${_basepath}/${_basename}.moc")
+
+    if(${QT_VERSION_MAJOR} EQUAL "5")
+        if(_basepath)
+           set(_moc "${CMAKE_CURRENT_BINARY_DIR}/${_basepath}/${_basename}.moc")
+        else()
+           set(_moc "${CMAKE_CURRENT_BINARY_DIR}/${_basename}.moc")
+        endif()
     else()
-        set(_moc "${CMAKE_CURRENT_BINARY_DIR}/${_basename}.moc")
+        if(_basepath)
+            set(_moc "${CMAKE_CURRENT_BINARY_DIR}/${_basepath}/moc_${_basename}.cpp")
+        else()
+            set(_moc "${CMAKE_CURRENT_BINARY_DIR}/moc_${_basename}.cpp")
+        endif()
     endif()
 
     get_source_file_property(_nonamespace ${_interface} NO_NAMESPACE)
@@ -120,9 +129,9 @@ PRIVATE
 )
 target_link_libraries(dde-integration-dbus
 PUBLIC
-    Qt5::Concurrent
+    Qt::Concurrent
 PRIVATE
-    Qt5::Core Qt5::Gui Dtk::Core AppStreamQt launcher-utils)
+    Qt::Core Qt::Gui ${DTK_NS}::Core launcher-utils)
 
 if (AppStreamQt_FOUND)
     target_link_libraries(dde-integration-dbus

--- a/src/gioutils/CMakeLists.txt
+++ b/src/gioutils/CMakeLists.txt
@@ -21,7 +21,7 @@ PRIVATE
 
 target_include_directories(gio-utils PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(gio-utils PUBLIC
-    Qt5::Core
+    Qt::Core
     PkgConfig::GIO
 )
 

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -28,7 +28,7 @@ PRIVATE
 target_link_libraries(launcher-models PRIVATE
     Qt::Core
     Qt::Gui
-    Dtk::Core
+    ${DTK_NS}::Core
 
     gio-utils
     launcher-utils

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-find_package(Qt5 REQUIRED Quick)
-find_package(Dtk REQUIRED COMPONENTS Gui) # for DHiDPIHelper, probably can be replaced later
+find_package(Qt NAMES ${QT_NS} REQUIRED Quick)
+find_package(Dtk NAMES ${DTK_NS} REQUIRED COMPONENTS Gui) # for DHiDPIHelper, probably can be replaced later
 
 add_library(launcher-utils OBJECT)
 
@@ -18,4 +18,4 @@ PRIVATE
 )
 
 target_include_directories(launcher-utils PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-target_link_libraries(launcher-utils PRIVATE Qt::Core Qt::Gui Qt::Svg Dtk::Gui)
+target_link_libraries(launcher-utils PRIVATE Qt::Core Qt::Gui Qt::Svg ${DTK_NS}::Gui)


### PR DESCRIPTION
调整 CMake 写法，试图使其支持 Qt6 与 Dtk6。

注：目前 Dtk6 存在一些问题，所以目前关闭 `PREFER_QT_5` 也无法正常构建出 Qt 6 的 launchpad。
