### PR TITLE
chore(CI): build Qt 6 version by default for deepin CI

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,19 +9,18 @@ Build-Depends:
  libglib2.0-dev,
 # v-- to get systemduserunitdir from its pkg-config data
  systemd,
- qtbase5-dev,
- libqt5svg5-dev,
- qtdeclarative5-dev,
- qttools5-dev,
- qttools5-dev-tools,
- qtquickcontrols2-5-dev,
+ qt6-base-dev,
+ qt6-svg-dev,
+ qt6-declarative-dev,
+ qt6-tools-dev,
+ qt6-tools-dev-tools,
  libdtkcommon-dev,
- libdtkcore-dev,
+ libdtk6core-dev,
 # v-- provides qdbusxml2cpp-fix binary
- libdtkcore5-bin,
+ libdtk6core-bin,
 # v-- provides DHiDPIHelper
- libdtkgui-dev,
- libdtkdeclarative-dev,
+ libdtk6gui-dev,
+ libdtk6declarative-dev,
  libappstreamqt-dev
 Standards-Version: 4.6.0
 Rules-Requires-Root: no
@@ -31,12 +30,12 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
- qml-module-qtquick-layouts,
- qml-module-qtquick-window2,
- qml-module-qtquick-controls2,
- qml-module-qtquick-controls2-styles-chameleon,
+ qml6-module-qtquick-layouts,
+ qml6-module-qtquick-window,
+ qml6-module-qtquick-controls,
+ qml6-module-qtquick-controls2-styles-chameleon,
 # v-- actually should be depended by qqc2-styles-chameleon
- qml-module-qtgraphicaleffects
+ qml6-module-qt5compat-graphicaleffects
 Conflicts: dde-launcher
 Replaces: dde-launcher
 Description: <insert up to 60 chars description>

--- a/debian/rules
+++ b/debian/rules
@@ -16,4 +16,5 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 override_dh_auto_configure:
 		dh_auto_configure -- \
-			-DVERSION=$(DEB_VERSION_UPSTREAM)
+			-DVERSION=$(DEB_VERSION_UPSTREAM) \
+			-DPREFER_QT_5=OFF

--- a/src/models/multipageproxymodel.cpp
+++ b/src/models/multipageproxymodel.cpp
@@ -70,7 +70,7 @@ void MultipageProxyModel::commitDndOperation(const QString &dragId, const QStrin
         if (std::get<0>(dropOrigPos) != 0 && dropId != "internal/folders/0") return; // folder inside folder is not allowed
         if (dropId.startsWith("internal/folders/")) {
             // drop into existing folder
-            const int dropOrigFolder = dropId.midRef(17).toInt();
+            const int dropOrigFolder = QStringView{dropId}.mid(17).toInt();
             ItemsPage * srcFolder = folderById(std::get<0>(dragOrigPos));
             ItemsPage * dstFolder = folderById(dropOrigFolder);
             srcFolder->removeItem(dragId);
@@ -241,7 +241,7 @@ void MultipageProxyModel::saveItemArrangementToUserData()
 
     for (int i = 0; i < m_folderModel.rowCount(); i++) {
         const QString & id = m_folderModel.index(i, 0).data(AppItem::DesktopIdRole).toString();
-        itemArrangementSettings.beginGroup("fullscreen/" + id.midRef(17));
+        itemArrangementSettings.beginGroup("fullscreen/" + id.mid(17));
         ItemsPage * page = m_folders.value(id);
         int pageCount = page->pageCount();
         itemArrangementSettings.setValue("name", page->name());
@@ -267,7 +267,7 @@ std::tuple<int, int, int> MultipageProxyModel::findItem(const QString &id, bool 
             const QString & folderId = m_folderModel.index(i, 0).data(AppItem::DesktopIdRole).toString();
             std::tie(page, idx) = m_folders[folderId]->findItem(id);
             if (page != -1) {
-                return std::make_tuple(folderId.midRef(17).toInt(), page, idx);
+                return std::make_tuple(QStringView{folderId}.mid(17).toInt(), page, idx);
             }
         }
     }


### PR DESCRIPTION
deepin OBS 构建默认构建 Qt 6 版本。

注意：对于现存版本的打包移植，目前仍然建议使用 Qt 5 版本。

测试说明：安装后，先确保之前的 launchpad 实例已退出（`killall dde-launchpad`），然后尝试点击启动器图标使 launchpad 显示出来。若满足下面的简单要求，即说明此 PR 没问题：

1. 可显示出来/切换到小窗口启动器
2. 可显示出来/切换到全屏启动器
3. 小窗口启动器的分类方式切换在点击后可以切换左侧的分类方式
4. 点击应用可以启动应用
5. 点击启动器窗口外侧可使启动器被隐藏

**与 Qt 5 版本 launchpad 相比的显示效果差异**可提 bug，但问题大概都来自 DTK 的 Qt 6 支持。