### PR TITLE
chore: release dde-launchpad 0.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 if(NOT DEFINED VERSION)
-    set(VERSION 0.2.0)
+    set(VERSION 0.2.1)
 endif()
 
 project(dde-launchpad VERSION ${VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-launchpad (0.2.1) unstable; urgency=medium
+
+  * Adjust icon hover effect (https://github.com/linuxdeepin/developer-center/issues/6140)
+  * Ascii item should appears first (https://github.com/linuxdeepin/developer-center/issues/6152)
+  * Lower-case word should appears first (https://github.com/linuxdeepin/developer-center/issues/6159)
+  * Reset focus and search state when hide fullscreen frame (https://github.com/linuxdeepin/developer-center/issues/6162)
+  * Support Enter key to select category in alphabet category view (https://github.com/linuxdeepin/developer-center/issues/6154)
+
+ -- Gary Wang <wangzichong@deepin.org>  Tue, 14 Nov 2023 13:03:00 +0800
+
 dde-launchpad (0.2.0) unstable; urgency=medium
 
   * Initial implementation of the redesigned UI


### PR DESCRIPTION
Changelog:

  * Adjust icon hover effect (https://github.com/linuxdeepin/developer-center/issues/6140)
  * Ascii item should appears first (https://github.com/linuxdeepin/developer-center/issues/6152)
  * Lower-case word should appears first (https://github.com/linuxdeepin/developer-center/issues/6159)
  * Reset focus and search state when hide fullscreen frame (https://github.com/linuxdeepin/developer-center/issues/6162)
  * Support Enter key to select category in alphabet category view (https://github.com/linuxdeepin/developer-center/issues/6154)

Log: