### PR TITLE
chore: release dde-launchpad 0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 if(NOT DEFINED VERSION)
-    set(VERSION 0.2.2)
+    set(VERSION 0.3.0)
 endif()
 
 project(dde-launchpad VERSION ${VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-launchpad (0.3.0) unstable; urgency=medium
+
+  * Support drag and drop in fullscreen launcher
+  * Fix fullscreen to launch app (https://github.com/linuxdeepin/developer-center/issues/6364)
+  * Remove highlight animation (https://github.com/linuxdeepin/developer-center/issues/6368)
+  * Reset folder popup state when hidding launchpad (https://github.com/linuxdeepin/developer-center/issues/6369)
+  * Reset keyboard focus when using mouse wheel (https://github.com/linuxdeepin/developer-center/issues/6361)
+  * Add tooltip for Control Center button (https://github.com/linuxdeepin/developer-center/issues/6365)
+
+ -- Gary Wang <wangzichong@deepin.org>  Wed, 06 Dec 2023 18:06:00 +0800
+
 dde-launchpad (0.2.2) unstable; urgency=medium
 
   * add hover state for AppListView items


### PR DESCRIPTION
发布 dde-launchpad 0.3.0

Changelog:

  * 全屏启动器支持拖拖拽创建应用文件夹。
  * 修复全屏启动器回车启动应用失效的问题 (https://github.com/linuxdeepin/developer-center/issues/6364)
  * 移除高亮项切换时的动画 (https://github.com/linuxdeepin/developer-center/issues/6368)
  * 隐藏启动器时重置应用文件夹打开状态 (https://github.com/linuxdeepin/developer-center/issues/6369)
  * 使用滚轮翻页时重置键盘焦点状态 (https://github.com/linuxdeepin/developer-center/issues/6361)
  * 控制中心按钮增加 tooltip (https://github.com/linuxdeepin/developer-center/issues/6365)

Log: