### PR TITLE
refactor: use two different window for two modes

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -11,40 +11,7 @@ import org.deepin.dtk 1.0
 
 import org.deepin.launchpad 1.0
 
-ApplicationWindow {
-    id: root
-
-    property bool isMenuShown: false
-
-//    title: activeFocusItem + " " + (activeFocusItem ? activeFocusItem.Accessible.name : "")
-    width: 780
-    height: 600
-    visible: LauncherController.visible
-    flags: {
-        if (DebugHelper.useRegularWindow) {
-            return Qt.Window
-        }
-        if (LauncherController.currentFrame === "WindowedFrame") {
-            return (Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint | Qt.Tool) // X11BypassWindowManagerHint
-        } else {
-            return (Qt.FramelessWindowHint | Qt.Tool)
-        }
-    }
-    DWindow.enabled: !DebugHelper.useRegularWindow
-    DWindow.enableBlurWindow: true
-    DWindow.enableSystemResize: false
-    DWindow.enableSystemMove: false
-
-    onVisibleChanged: {
-        updateWindowVisibilityAndPosition()
-    }
-
-    onActiveChanged: {
-        if (!active && !isMenuShown && !DebugHelper.avoidHideWindow) {
-            LauncherController.hideWithTimer()
-        }
-    }
-
+QtObject {
     function getCategoryName(section) {
         switch (Number(section)) {
         case AppItem.Internet:
@@ -72,11 +39,6 @@ ApplicationWindow {
         }
     }
 
-    function descaledRect(rect) {
-        let ratio = Screen.devicePixelRatio
-        return Qt.rect(rect.left / ratio, rect.top / ratio, rect.width / ratio, rect.height / ratio)
-    }
-
     function launchApp(desktopId) {
         if (DebugHelper.avoidLaunchApp) {
             DTK.sendSystemMessage("dde-launchpad (debug)",
@@ -99,16 +61,16 @@ ApplicationWindow {
             isFavoriteItem: isFavoriteItem,
             hideFavoriteMenu: hideFavoriteMenu
         });
-        menu.closed.connect(function() {
-            root.isMenuShown = false
-            root.requestActivate()
-        });
         menu.popup();
-        root.isMenuShown = true
+    }
+
+    function descaledRect(rect) {
+        let ratio = Screen.devicePixelRatio
+        return Qt.rect(rect.left / ratio, rect.top / ratio, rect.width / ratio, rect.height / ratio)
     }
 
     function updateWindowVisibilityAndPosition() {
-        if (!root.visible) return;
+        if (!LauncherController.visible) return;
 
         if (LauncherController.currentFrame === "WindowedFrame") {
 //            root.visibility = Window.Windowed
@@ -142,60 +104,122 @@ ApplicationWindow {
 
             // Window mode: follow system theme
             ApplicationHelper.setPaletteType(ApplicationHelper.UnknownType)
-            root.setGeometry(x, y, width, height)
+            windowedFrame.setGeometry(x, y, width, height)
+            windowedFrame.requestActivate()
         } else {
 //            root.visibility = Window.FullScreen
             // Fullscreen mode: always assume dark theme
             ApplicationHelper.setPaletteType(ApplicationHelper.DarkType)
-            root.setGeometry(Screen.virtualX, Screen.virtualY, Screen.width, Screen.height)
+            fullscreenFrame.setGeometry(Screen.virtualX, Screen.virtualY, Screen.width, Screen.height)
+            fullscreenFrame.requestActivate()
         }
-
-        root.requestActivate()
     }
 
-    Connections {
+    property var windowedFrame: ApplicationWindow {
+        visible: LauncherController.visible && (LauncherController.currentFrame === "WindowedFrame")
+
+        width: 780
+        height: 600
+        flags: {
+            if (DebugHelper.useRegularWindow) return Qt.Window
+            return (Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint | Qt.Tool)
+        }
+
+        DWindow.enabled: !DebugHelper.useRegularWindow
+        DWindow.enableBlurWindow: true
+        DWindow.enableSystemResize: false
+        DWindow.enableSystemMove: false
+
+        onVisibleChanged: {
+            updateWindowVisibilityAndPosition()
+        }
+
+        onActiveChanged: {
+            if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "WindowedFrame")) {
+                LauncherController.hideWithTimer()
+            }
+        }
+
+        Loader {
+            anchors.fill: parent
+            focus: true
+            source: "WindowedFrame.qml"
+
+            Label {
+                visible: DebugHelper.qtDebugEnabled
+                z: 999
+
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                text: "/ / Under Construction / /"
+
+                background: Rectangle {
+                    color: Qt.rgba(1, 1, 0, 0.5)
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: { debugDialog.open() }
+                }
+            }
+        }
+    }
+
+    property var fullscreenFrame: ApplicationWindow {
+        visible: LauncherController.visible && (LauncherController.currentFrame !== "WindowedFrame")
+
+        width: Screen.width
+        height: Screen.height
+        // visibility: Window.FullScreen
+        flags: {
+            if (DebugHelper.useRegularWindow) return Qt.Window
+            return (Qt.FramelessWindowHint | Qt.Tool)
+        }
+
+        DWindow.enabled: !DebugHelper.useRegularWindow
+        DWindow.enableSystemResize: false
+        DWindow.enableSystemMove: false
+
+        Loader {
+            anchors.fill: parent
+            focus: true
+            source: "FullscreenFrame.qml"
+
+            Label {
+                visible: DebugHelper.qtDebugEnabled
+                z: 999
+
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                text: "/ / Under Construction / /"
+
+                background: Rectangle {
+                    color: Qt.rgba(1, 1, 0, 0.5)
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: { debugDialog.open() }
+                }
+            }
+        }
+    }
+
+    property var desktopIntegrationConn: Connections {
         target: DesktopIntegration
         function onDockGeometryChanged() {
             updateWindowVisibilityAndPosition()
         }
     }
 
-    Loader {
-        id: frameLoader
-        anchors.fill: parent
-        focus: true
-        source: LauncherController.currentFrame + ".qml"
-        onSourceChanged: {
-            updateWindowVisibilityAndPosition();
-        }
-
-        Label {
-            visible: DebugHelper.qtDebugEnabled
-            z: 999
-
-            anchors.right: parent.right
-            anchors.bottom: parent.bottom
-            text: "/ / Under Construction / /"
-
-            background: Rectangle {
-                color: Qt.rgba(1, 1, 0, 0.5)
-            }
-
-            MouseArea {
-                anchors.fill: parent
-                onClicked: { debugDialog.open() }
-            }
-        }
-    }
-
-    Dialog {
+    property var debugDialog: DialogWindow {
         id: debugDialog
-        modal: true
 
-        standardButtons: Dialog.Close
-
-        x: (parent.width - width) / 2
-        y: (parent.height - height) / 2
+        width: 400
+        height: 400
+        function open() {
+            show()
+        }
 
         Loader {
             active: debugDialog.visible
@@ -204,7 +228,7 @@ ApplicationWindow {
         }
     }
 
-    DialogWindow {
+    property var uninstallDialog: DialogWindow {
         id: confirmUninstallDlg
 
         property string appId: ""


### PR DESCRIPTION
全屏和小窗口启动器现转而使用不同的两个窗口来管理窗口位置与状态，以此避免共用窗口导致的窗口状态切换时，布局不必要的重新加载导致的卡顿问题。
