### PR TITLE
fix: reset keyboard focus even searchEdit focus

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -86,11 +86,15 @@ Control {
                     }
                     if (toPage < 0) {
                         flipPageDelay.start()
-                        baseLayer.focus = true // reset keyboard focus when using mouse to flip page
+                        if (!searchEdit.focus) { // reset keyboard focus when using mouse to flip page, but keep searchEdit focus
+                            baseLayer.focus = true
+                        }
                         pages.decrementCurrentIndex()
                     } else if (toPage > 0) {
                         flipPageDelay.start()
-                        baseLayer.focus = true // reset keyboard focus when using mouse to flip page
+                        if (!searchEdit.focus) { // reset keyboard focus when using mouse to flip page, but keep searchEdit focus
+                            baseLayer.focus = true
+                        }
                         pages.incrementCurrentIndex()
                     }
                 }


### PR DESCRIPTION
keep searchEdit focus when flip page

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/6398