### PR TITLE
fix: abnormal view of applistview

### DIFF
--- a/qml/AppListView.qml
+++ b/qml/AppListView.qml
@@ -34,7 +34,7 @@ Item {
             if (character === transliterated1st) {
                 // we use the highlight move to scroll to item
                 listView.highlightMoveDuration = 0
-                listView.highlightRangeMode = ListView.StrictlyEnforceRange
+                listView.highlightRangeMode = ListView.ApplyRange
                 listView.currentIndex = i
                 postScrollDeferTimer.restart()
                 break
@@ -90,8 +90,11 @@ Item {
             if (activeFocus) {
                 // When focus in, we always scroll to the highlight
                 listView.highlightMoveDuration = 0
+                listView.currentIndex = 0
                 listView.highlightRangeMode = ListView.StrictlyEnforceRange
                 postScrollDeferTimer.restart()
+            } else {
+                listView.currentIndex = -1
             }
         }
 

--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -73,8 +73,11 @@ FocusScope {
                 onActiveFocusChanged: {
                     if (activeFocus) {
                         gridView.highlightMoveDuration = 0
+                        gridView.currentIndex = 0
                         gridView.highlightRangeMode = GridView.StrictlyEnforceRange
                         postScrollDeferTimer.restart()
+                    } else {
+                        gridView.currentIndex = -1
                     }
                 }
                 cellHeight: item.cellSize


### PR DESCRIPTION
 * Cause highlight move forcely position highlight item at the top, We revert to ApplyRange.
 * Every time focus in, we set the currentIndex to 0, and every time focus out, we clear currentItem.

Log: fix abnormal view of applistview