### PR TITLE
fix: reset scrollview/swipeview position when hide

### DIFF
--- a/qml/AppListView.qml
+++ b/qml/AppListView.qml
@@ -28,6 +28,10 @@ Item {
         }
     }
 
+    function positionViewAtBeginning() {
+        listView.positionViewAtBeginning()
+    }
+
     function scrollToAlphabetCategory(character) {
         for (let i = 0; i < model.count; i++) {
             let transliterated1st = model.model.data(model.modelIndex(i), 4096)[0].toUpperCase() // 4096 is AppsModel::TransliteratedRole

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -526,6 +526,8 @@ Control {
             if (folderGridViewPopup.visible) folderGridViewPopup.close()
             // reset(remove) keyboard focus
             baseLayer.focus = true
+            // reset page to the first page
+            pages.setCurrentIndex(0)
         }
     }
 }

--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -29,6 +29,10 @@ FocusScope {
 
     readonly property alias gridViewWidth: gridView.width
 
+    function positionViewAtBeginning() {
+        gridView.positionViewAtBeginning()
+    }
+
     function itemAt(x, y) {
         let point = mapToItem(gridView, x, y)
         return gridView.itemAt(point.x, point.y)

--- a/qml/WindowedFrame.qml
+++ b/qml/WindowedFrame.qml
@@ -336,6 +336,10 @@ StackView {
             searchEdit.text = ""
             // reset(remove) keyboard focus
             baseLayer.focus = true
+            // reset scroll area position
+            appListView.positionViewAtBeginning()
+            favoriteGridViewContainer.positionViewAtBeginning()
+            allAppsGridContainer.positionViewAtBeginning()
         }
     }
 }


### PR DESCRIPTION
隐藏启动器时，重置可滚动/翻页区域的位置到最顶部/首页。

Issue: https://github.com/linuxdeepin/developer-center/issues/6402