### PR TITLE
chore: release dde-launchpad 0.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 if(NOT DEFINED VERSION)
-    set(VERSION 0.4.0)
+    set(VERSION 0.4.1)
 endif()
 
 project(dde-launchpad VERSION ${VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-launchpad (0.4.1) unstable; urgency=medium
+
+  * Ensure dxcb plugin can be loaded properly (https://github.com/linuxdeepin/developer-center/issues/6686)
+  * Reset scrollview/swipeview position when launchpad hide (https://github.com/linuxdeepin/developer-center/issues/6402)
+  * Fix double focus box in AppListView (https://github.com/linuxdeepin/developer-center/issues/6401)
+  * Fix highlight range in AppListView (https://github.com/linuxdeepin/developer-center/issues/6151)
+  * Fix the height of the uninstallation confirm dialog (https://github.com/linuxdeepin/developer-center/issues/6687)
+  * Avoid scroll mouse to reset the search edit input focus (https://github.com/linuxdeepin/developer-center/issues/6398)
+
+ -- Gary Wang <wangzichong@deepin.org>  Wed, 10 Jan 2024 13:43:00 +0800
+
 dde-launchpad (0.4.0) unstable; urgency=medium
 
   * Rename "Settings" to "Control Center"


### PR DESCRIPTION
Please refer to debian/changelog for detailed changelog

Log: