### PR TITLE
fix: position jitter between two presentations

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -85,6 +85,11 @@ QRect DesktopIntegration::dockGeometry() const
     return m_dockIntegration->geometry();
 }
 
+uint DesktopIntegration::dockSpacing() const
+{
+    return m_dockIntegration->windowMargin();
+}
+
 QString DesktopIntegration::backgroundUrl() const
 {
     return QString("image://blurhash/%1").arg(m_appearanceIntegration->wallpaperBlurhash());
@@ -219,5 +224,6 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
 {
     connect(m_dockIntegration, &DdeDock::directionChanged, this, &DesktopIntegration::dockPositionChanged);
     connect(m_dockIntegration, &DdeDock::geometryChanged, this, &DesktopIntegration::dockGeometryChanged);
+    connect(m_dockIntegration, &DdeDock::windowMarginChanged, this, &DesktopIntegration::dockSpacingChanged);
     connect(m_appearanceIntegration, &Appearance::wallpaperBlurhashChanged, this, &DesktopIntegration::backgroundUrlChanged);
 }

--- a/desktopintegration.h
+++ b/desktopintegration.h
@@ -16,6 +16,7 @@ class DesktopIntegration : public QObject
 
     Q_PROPERTY(Qt::ArrowType dockPosition READ dockPosition NOTIFY dockPositionChanged)
     Q_PROPERTY(QRect dockGeometry READ dockGeometry NOTIFY dockGeometryChanged)
+    Q_PROPERTY(uint dockSpacing READ dockSpacing NOTIFY dockSpacingChanged)
     Q_PROPERTY(QString backgroundUrl READ backgroundUrl NOTIFY backgroundUrlChanged)
 
 public:
@@ -34,6 +35,7 @@ public:
 
     Qt::ArrowType dockPosition() const;
     QRect dockGeometry() const;
+    uint dockSpacing() const;
     QString backgroundUrl() const;
 
     Q_INVOKABLE bool isDockedApp(const QString & desktopId) const;
@@ -49,6 +51,7 @@ public:
 signals:
     void dockPositionChanged();
     void dockGeometryChanged();
+    void dockSpacingChanged();
     void backgroundUrlChanged();
 
 private:

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -85,18 +85,18 @@ QtObject {
                 switch (DesktopIntegration.dockPosition) {
                 case Qt.DownArrow:
                     x = dockGeometry.left
-                    y = (dockGeometry.top >= 0 ? dockGeometry.top : (Screen.height - dockGeometry.height)) - height
+                    y = (dockGeometry.top >= 0 ? dockGeometry.top : (Screen.height - dockGeometry.height)) - height - DesktopIntegration.dockSpacing
                     break
                 case Qt.LeftArrow:
-                    x = dockGeometry.width
+                    x = dockGeometry.right + DesktopIntegration.dockSpacing
                     y = (dockGeometry.top >= 0 ? dockGeometry.top : 0)
                     break
                 case Qt.UpArrow:
                     x = dockGeometry.left
-                    y = dockGeometry.height
+                    y = dockGeometry.bottom + DesktopIntegration.dockSpacing
                     break
                 case Qt.RightArrow:
-                    x = (dockGeometry.left >= 0 ? dockGeometry.left : (Screen.width - dockGeometry.width)) - width
+                    x = (dockGeometry.left >= 0 ? dockGeometry.left : (Screen.width - dockGeometry.width)) - width - DesktopIntegration.dockSpacing
                     y = dockGeometry.top
                     break
                 }

--- a/src/ddeintegration/ddedock.cpp
+++ b/src/ddeintegration/ddedock.cpp
@@ -16,12 +16,15 @@ DdeDock::DdeDock(QObject *parent)
                                       QDBusConnection::sessionBus(), this))
     , m_direction(Qt::DownArrow)
     , m_rect(QRect(-1, -1, 0, 0))
+    , m_windowMargin(0)
 {
     QTimer::singleShot(0, this, &DdeDock::updateDockRectAndPositionFromDBus);
+    QMetaObject::invokeMethod(this, &DdeDock::updateDockWindowMarginFromDBus, Qt::QueuedConnection);
 
     // Due to current dde-dock bug, we need to do both since position changed signal might not got emit in some case.
     connect(m_dbusDaemonDockIface, &Dock1::PositionChanged, this, &DdeDock::updateDockRectAndPositionFromDBus);
     connect(m_dbusDaemonDockIface, &Dock1::FrontendWindowRectChanged, this, &DdeDock::updateDockRectAndPositionFromDBus);
+    connect(m_dbusDaemonDockIface, &Dock1::WindowMarginChanged, this, &DdeDock::updateDockWindowMarginFromDBus);
 }
 
 DdeDock::~DdeDock()
@@ -37,6 +40,11 @@ Qt::ArrowType DdeDock::direction() const
 QRect DdeDock::geometry() const
 {
     return m_rect;
+}
+
+uint DdeDock::windowMargin() const
+{
+    return m_windowMargin;
 }
 
 bool DdeDock::isDocked(const QString &desktop) const
@@ -97,6 +105,12 @@ void DdeDock::updateDockPositionFromDBus()
         m_direction = newDirection;
         emit directionChanged();
     }
+}
+
+void DdeDock::updateDockWindowMarginFromDBus()
+{
+    m_windowMargin = m_dbusDaemonDockIface->windowMargin();
+    emit windowMarginChanged();
 }
 
 void DdeDock::updateDockRectFromDBus()

--- a/src/ddeintegration/ddedock.h
+++ b/src/ddeintegration/ddedock.h
@@ -14,6 +14,7 @@ class DdeDock : public QObject
 
     Q_PROPERTY(Qt::ArrowType direction READ direction NOTIFY directionChanged)
     Q_PROPERTY(QRect geometry READ geometry NOTIFY geometryChanged)
+    Q_PROPERTY(uint windowMargin READ windowMargin NOTIFY windowMarginChanged)
 
 public:
     explicit DdeDock(QObject *parent = nullptr);
@@ -21,6 +22,7 @@ public:
 
     Qt::ArrowType direction() const;
     QRect geometry() const;
+    uint windowMargin() const;
 
     bool isDocked(const QString & desktop) const;
     void sendToDock(const QString & desktop, int idx = -1);
@@ -29,14 +31,17 @@ public:
 signals:
     void directionChanged();
     void geometryChanged();
+    void windowMarginChanged();
 
 private:
     void updateDockRectAndPositionFromDBus();
     void updateDockPositionFromDBus();
+    void updateDockWindowMarginFromDBus();
     void updateDockRectFromDBus();
 
     __Dock1 * m_dbusDaemonDockIface;
 
     Qt::ArrowType m_direction;
     QRect m_rect;
+    uint m_windowMargin;
 };

--- a/src/ddeintegration/xml/org.deepin.dde.daemon.Dock1.xml
+++ b/src/ddeintegration/xml/org.deepin.dde.daemon.Dock1.xml
@@ -89,6 +89,7 @@
   <property name="WindowSize" type="u" access="readwrite"/>
   <property name="WindowSizeEfficient" type="u" access="readwrite"/>
   <property name="WindowSizeFashion" type="u" access="readwrite"/>
+  <property name="WindowMargin" type="u" access="read"/>
   <property name="ShowTimeout" type="u" access="readwrite"/>
   <property name="HideTimeout" type="u" access="readwrite"/>
   <property name="DockedApps" type="as" access="read"/>


### PR DESCRIPTION
In first presentation, there is no distance to dock. But the second presentation will bring a spacing to Dock. Always add a spacing to Dock.

Log: fix position jitter between two presentations
Issue: https://github.com/linuxdeepin/developer-center/issues/6733
Depends: https://github.com/linuxdeepin/dde-dock/pull/956