### PR TITLE
fix: failed to fallback default icon

### DIFF
--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -64,8 +64,10 @@ bool IconUtils::getThemeIcon(QPixmap &pixmap, const QString &iconName, const int
 
         icon = DIconTheme::findQIcon(actualIconName);
 
-        if (icon.isNull()) {
+        // TODO why icon is not null, but it's name is empty.
+        if (icon.isNull() || icon.name().isEmpty()) {
             icon = QIcon(":/images/application-x-desktop.svg");
+            qWarning() << "It fallbacks to default icon for [" << actualIconName << "].";
             findIcon = false;
         }
 


### PR DESCRIPTION
  It's maybe a bug for deepin-app-store-tool. App's icon is installed
in /opt, the tool will create a link for it's icons, but the action
is async, icon-theme.cache is not ready when launchpad is read.
  and we only ensure display an X icon when icon is invalid.

Issue: https://github.com/linuxdeepin/developer-center/issues/6860
