### PR TITLE
fix: can't find icon in qt6

### DIFF
--- a/src/models/appsmodel.cpp
+++ b/src/models/appsmodel.cpp
@@ -4,6 +4,7 @@
 
 #include "appsmodel.h"
 #include "categoryutils.h"
+#include "iconutils.h"
 
 #include <QDebug>
 #include <DConfig>
@@ -37,6 +38,8 @@ AppsModel::AppsModel(QObject *parent)
 
     connect(m_appInfoMonitor, &AppInfoMonitor::changed, this, [this](){
         qDebug() << "changed";
+        // TODO release icon's cache when gtk's icon-theme.cache is updated.
+        IconUtils::tryUpdateIconCache();
         QList<AppItem *> items(allAppInfosShouldBeShown());
         cleanUpInvalidApps(items);
         QList<AppItem *> duplicatedItems = updateItems(items);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -18,4 +18,4 @@ PRIVATE
 )
 
 target_include_directories(launcher-utils PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-target_link_libraries(launcher-utils PRIVATE Qt::Core Qt::Gui Qt::Svg ${DTK_NS}::Gui)
+target_link_libraries(launcher-utils PRIVATE Qt::Core Qt::Gui Qt::GuiPrivate Qt::Svg ${DTK_NS}::Gui)

--- a/src/utils/iconutils.cpp
+++ b/src/utils/iconutils.cpp
@@ -4,6 +4,8 @@
 
 #include "iconutils.h"
 
+#include <private/qiconloader_p.h>
+
 #include <QDate>
 #include <QDebug>
 #include <QIcon>
@@ -240,4 +242,12 @@ const QPixmap IconUtils::loadSvg(const QString &fileName, const QSize &size)
     painter.end();
 
     return pixmap;
+}
+
+void IconUtils::tryUpdateIconCache()
+{
+    qInfo() << "Update theme cache manually.";
+    // TODO release icon's cache.
+    const auto paths = QIconLoader::instance()->themeSearchPaths();
+    QIconLoader::instance()->setThemeSearchPath(paths);
 }

--- a/src/utils/iconutils.h
+++ b/src/utils/iconutils.h
@@ -8,6 +8,7 @@
 
 namespace IconUtils {
 bool getThemeIcon(QPixmap &pixmap, const QString & iconName, const int size);
+void tryUpdateIconCache();
 int perfectIconSize(const int size);
 bool createCalendarIcon(const QString &fileName);
 const QPixmap loadSvg(const QString &fileName, int size);


### PR DESCRIPTION
  It maybe a bug for qt.
  xdgicon has not adapt to qt6, so we use Qt's QIconLoaderEngine
to find icon for xdg icon in dtkgui, but `icon-theme.cache` is read once in
QIconCacheGtkReader, so it's not updated even if `gtk-update-cache-icon`
is executed in deepin-app-store-tool before reading icon.
  we release cache when `changed` signal received.

Issue: https://github.com/linuxdeepin/developer-center/issues/6860
