### PR TITLE
fix: use timer to avoid window hide caused by switching mode

### DIFF
--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -127,6 +127,7 @@ void LauncherController::setCurrentFrame(const QString &frame)
     settings.setValue("current_frame", frame);
 
     m_currentFrame = frame;
+    m_timer->start();
     emit currentFrameChanged();
 }
 
@@ -140,4 +141,9 @@ void LauncherController::hideWithTimer()
         m_timer->start();
         setVisible(false);
     }
+}
+
+bool LauncherController::shouldAvoidHideOrActive()
+{
+    return m_timer->isActive();
 }

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -35,6 +35,7 @@ public:
     void setCurrentFrame(const QString & frame);
 
     Q_INVOKABLE void hideWithTimer();
+    Q_INVOKABLE bool shouldAvoidHideOrActive();
 
 signals:
     void currentFrameChanged();

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -137,7 +137,13 @@ QtObject {
 
         onActiveChanged: {
             if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "WindowedFrame")) {
-                LauncherController.hideWithTimer()
+                // When composting is disabled, switching mode from fullscreen to windowed mode will cause window
+                // activeChanged signal get emitted. We reused the delay timer here to avoid the window get hide
+                // caused by that.
+                // Issue: https://github.com/linuxdeepin/developer-center/issues/6818
+                if (!LauncherController.shouldAvoidHideOrActive()) {
+                    LauncherController.hideWithTimer()
+                }
             }
         }
 


### PR DESCRIPTION
复用了现有的 timer 来避免在无混成时切换 launchpad 模式时失去焦点导致的窗口隐藏。

Issue: https://github.com/linuxdeepin/developer-center/issues/6818