### PR TITLE
fix: search edit width not correct

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -356,7 +356,7 @@ Control {
             id: searchEdit
 
             Layout.alignment: Qt.AlignHCenter
-            width: (parent.width / 2) > 400 ? 400 : (parent.width / 2)
+            implicitWidth: (parent.width / 2) > 280 ? 280 : (parent.width / 2)
 
             placeholder: qsTranslate("WindowedFrame", "Search")
             onTextChanged: {


### PR DESCRIPTION
Use implicit width to tell column layout the preferred width. Adjust preferred width to 280.

Log: fix search edit width not correct