### PR TITLE
chore: release dde-launchpad 0.4.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 if(NOT DEFINED VERSION)
-    set(VERSION 0.4.5)
+    set(VERSION 0.4.6)
 endif()
 
 project(dde-launchpad VERSION ${VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-launchpad (0.4.6) unstable; urgency=medium
+
+  * Adapt UI changes according to designer
+  * Fix tab and space and trigger quick search
+  * Add pre-defined apps to launchpad favorited app list
+
+ -- Gary Wang <wangzichong@deepin.org>  Wed, 31 Jan 2024 18:53:00 +0800
+
 dde-launchpad (0.4.5) unstable; urgency=medium
 
   * Ensure icon change when theme change

--- a/src/models/favoritedproxymodel.cpp
+++ b/src/models/favoritedproxymodel.cpp
@@ -79,7 +79,7 @@ void FavoritedProxyModel::load()
     QSettings favoritedAppsSettings(favoriteSettingPath, QSettings::NativeFormat);
 
     QStringList predefinedFavoritedApps {
-        "deepin-editor.desktop", "deepin-calculator.desktop", "deepin-screen-recorder.desktop", "eepin-terminal.desktop"
+        "deepin-editor.desktop", "deepin-calculator.desktop", "deepin-screen-recorder.desktop", "deepin-terminal.desktop"
     };
     m_favoritedAppIds = favoritedAppsSettings.value("favorited", predefinedFavoritedApps).toStringList();
 }


### PR DESCRIPTION
Changelog:

  * Adapt UI changes according to designer
  * Fix tab and space and trigger quick search
  * Add pre-defined apps to launchpad favorited apps

Log: