### PR TITLE
fix: should skip tab for fast search

### DIFF
--- a/qml/WindowedFrame.qml
+++ b/qml/WindowedFrame.qml
@@ -303,7 +303,7 @@ StackView {
         if ((event.text && !"\t ".includes(event.text)) && (stackView.currentItem !== stackView.initialItem)) {
             stackView.pop()
         }
-        if (searchEdit.focus === false && !searchEdit.text && event.text) {
+        if (searchEdit.focus === false && !searchEdit.text && (event.text && !"\t ".includes(event.text))) {
             searchEdit.focus = true
             searchEdit.text = event.text
         }


### PR DESCRIPTION
Tab 不应当触发快速搜索

Issues: linuxdeepin/developer-center#7204