### PR TITLE
chore: use AM api to manage shortcut and autostart

### DIFF
--- a/src/ddeintegration/appmgr.cpp
+++ b/src/ddeintegration/appmgr.cpp
@@ -111,18 +111,34 @@ bool AppMgr::isOnDesktop(const QString &desktopId)
     return amAppIface->isOnDesktop();
 }
 
-void AppMgr::sendToDesktop(const QString &desktopId)
+bool AppMgr::sendToDesktop(const QString &desktopId)
 {
     AppManager1Application * amAppIface = createAM1AppIface(desktopId);
-    if (!amAppIface) return;
+    if (!amAppIface) return false;
 
-    amAppIface->SendToDesktop();
+    QDBusPendingReply<bool> reply = amAppIface->SendToDesktop();
+    reply.waitForFinished();
+
+    if (reply.isError()) {
+        qDebug() << reply.error();
+        return false;
+    }
+
+    return reply.value();
 }
 
-void AppMgr::removeFromDesktop(const QString &desktopId)
+bool AppMgr::removeFromDesktop(const QString &desktopId)
 {
     AppManager1Application * amAppIface = createAM1AppIface(desktopId);
-    if (!amAppIface) return;
+    if (!amAppIface) return false;
 
-    amAppIface->RemoveFromDesktop();
+    QDBusPendingReply<bool> reply = amAppIface->RemoveFromDesktop();
+    reply.waitForFinished();
+
+    if (reply.isError()) {
+        qDebug() << reply.error();
+        return false;
+    }
+
+    return reply.value();
 }

--- a/src/ddeintegration/appmgr.h
+++ b/src/ddeintegration/appmgr.h
@@ -19,6 +19,6 @@ public:
     static double scaleFactor(const QString & desktopId);
     static void setScaleFactor(const QString & desktopId, double scaleFactor);
     static bool isOnDesktop(const QString & desktopId);
-    static void sendToDesktop(const QString & desktopId);
-    static void removeFromDesktop(const QString & desktopId);
+    static bool sendToDesktop(const QString & desktopId);
+    static bool removeFromDesktop(const QString & desktopId);
 };


### PR DESCRIPTION
Use dde-application-manager's dbus API to manage desktop shortcut and autostart.

cc @ComixHe