### PR TITLE
refact: separate Windowed as a plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(src/utils)
 add_subdirectory(src/quick)
 add_subdirectory(src/ddeintegration)
 add_subdirectory(src/models)
+add_subdirectory(qml/windowed)
 
 set(SOURCE_FILES
     main.cpp
@@ -56,12 +57,12 @@ set(SOURCE_FILES
 set(QML_FILES
     qml/Helper.qml
     qml/Main.qml
-    qml/WindowedFrame.qml
-    qml/windowed/SideBar.qml
-    qml/windowed/AlphabetCategoryPopup.qml
-    qml/windowed/AppListView.qml
     qml/FullscreenFrame.qml
     qml/AppItemMenu.qml
+    qml/GridViewContainer.qml
+    qml/DrawerFolder.qml
+    qml/IconItemDelegate.qml
+    qml/DebugDialog.qml
 )
 
 set_source_files_properties(qml/Helper.qml
@@ -104,8 +105,10 @@ qt_add_qml_module(${BIN_NAME}
     URI org.deepin.launchpad
     VERSION 1.0
     RESOURCES qml.qrc
+    RESOURCE_PREFIX
+        /qt/qml
     QML_FILES
-        qml/Helper.qml
+        ${QML_FILES}
 )
 
 qt_add_translations(${BIN_NAME}
@@ -126,6 +129,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Qt::Quick
     Qt::QuickControls2
 
+    launcher-qml-windowed
     gio-utils
     launcher-utils
     launcher-qml-utils

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
 
     QQmlContext * ctx = engine.rootContext();
 
-    engine.load(QUrl("qrc:/qml/Main.qml"));
+    engine.loadFromModule("org.deepin.launchpad", "Main");
     if (engine.rootObjects().isEmpty())
         return -1;
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -1,16 +1,5 @@
 <RCC>
     <qresource prefix="/">
-        <file>qml/Main.qml</file>
-        <file>qml/windowed/SideBar.qml</file>
-        <file>qml/windowed/AppList.qml</file>
-        <file>qml/windowed/AppListView.qml</file>
-        <file>qml/windowed/AlphabetCategoryPopup.qml</file>
-        <file>qml/DebugDialog.qml</file>
-        <file>qml/FullscreenFrame.qml</file>
-        <file>qml/WindowedFrame.qml</file>
-        <file>qml/IconItemDelegate.qml</file>
-        <file>qml/GridViewContainer.qml</file>
-        <file>qml/AppItemMenu.qml</file>
         <file>images/application-x-desktop.svg</file>
     </qresource>
     <qresource prefix="/dsg/built-in-icons">

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -12,6 +12,7 @@ import org.deepin.dtk.style 1.0 as DS
 
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
+import org.deepin.launchpad.windowed 1.0
 
 QtObject {
     function getCategoryName(section) {
@@ -185,7 +186,7 @@ QtObject {
         Loader {
             anchors.fill: parent
             focus: true
-            source: "WindowedFrame.qml"
+            sourceComponent: WindowedFrame { }
 
             Label {
                 visible: DebugHelper.qtDebugEnabled

--- a/qml/windowed/AlphabetCategoryPopup.qml
+++ b/qml/windowed/AlphabetCategoryPopup.qml
@@ -12,8 +12,6 @@ import org.deepin.dtk 1.0
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
 
-import ".."
-
 Popup {
     id: gridPopup
     width: 180

--- a/qml/windowed/CMakeLists.txt
+++ b/qml/windowed/CMakeLists.txt
@@ -1,0 +1,15 @@
+qt_add_qml_module(launcher-qml-windowed
+    URI org.deepin.launchpad.windowed
+    STATIC
+    VERSION 1.0
+    PLUGIN_TARGET launcher-qml-windowed
+    RESOURCE_PREFIX
+        /qt/qml
+    QML_FILES
+        SideBar.qml
+        AlphabetCategoryPopup.qml
+        AppList.qml
+        AppListView.qml
+        IconItemDelegate.qml
+        WindowedFrame.qml
+)

--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQml.Models 2.15
+import QtQuick.Controls 2.15
+import org.deepin.dtk 1.0
+import org.deepin.dtk.private 1.0
+
+import org.deepin.launchpad 1.0
+
+Control {
+    id: root
+
+    width: 96
+    height: 96
+
+    property var icons: undefined
+    property int preferredIconSize: 48
+    property string text: display.startsWith("internal/category/") ? getCategoryName(display.substring(18)) : display
+
+    property string iconSource
+    property bool dndEnabled: false
+
+    Accessible.name: iconItemLabel.text
+
+    signal folderClicked()
+    signal itemClicked()
+
+    contentItem: ToolButton {
+        focusPolicy: Qt.NoFocus
+        contentItem: Column {
+            anchors.fill: parent
+
+            Item {
+                // actually just a top padding
+                width: root.width
+                height: root.height / 9
+            }
+
+            Rectangle {
+                visible: false
+                anchors.right: parent.right
+
+                color: "blue"
+
+                width: 6
+                height: 6
+                radius: width / 2
+            }
+
+            Item {
+                width: 48
+                height: width
+                anchors.horizontalCenter: parent.horizontalCenter
+
+                Loader {
+                    id: iconLoader
+                    anchors.fill: parent
+                    sourceComponent: root.icons !== undefined ? folderComponent : imageComponent
+                }
+
+                Component {
+                    id: folderComponent
+
+                    Image {
+                        id: iconImage
+                        anchors.fill: parent
+                        source: "image://folder-icon/" + icons.join(':')
+                        sourceSize: Qt.size(parent.width, parent.height)
+                    }
+                }
+
+                Component {
+                    id: imageComponent
+
+                    DciIcon {
+                        objectName: "appIcon"
+                        anchors.fill: parent
+                        name: iconSource
+                        sourceSize: Qt.size(parent.width, parent.height)
+                    }
+                }
+            }
+
+            // as topMargin
+            Item {
+                width: 1
+                height: 8
+            }
+
+            Label {
+                id: iconItemLabel
+                text: root.text
+                textFormat: Text.PlainText
+                width: parent.width
+                leftPadding: 2
+                rightPadding: 2
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                elide: Text.ElideMiddle
+                maximumLineCount: 2
+                font: DTK.fontManager.t8
+            }    
+        }
+        background: ButtonPanel {
+            button: parent
+            outsideBorderColor: null
+            radius: 8
+        }
+
+        onClicked: {
+            if (root.icons) {
+                root.folderClicked()
+            } else {
+                root.itemClicked()
+            }
+        }
+    }
+}

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -12,8 +12,6 @@ import org.deepin.dtk 1.0
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
 
-import "windowed"
-
 Item {
     id: baseLayer
     objectName: "WindowedFrame-BaseLayer"


### PR DESCRIPTION
  In order to facilitate the next step of porting to dde-shell.
  Windowed's IconItemDelegate is different with FullWindow, so
we add an new IconItemDelegate.
