### PR TITLE
fix: recentlyInstalledModel is empty

### DIFF
--- a/qml/windowed/RecentlyInstalledView.qml
+++ b/qml/windowed/RecentlyInstalledView.qml
@@ -37,7 +37,9 @@ Control {
             Layout.topMargin: 6
 
             model: CountLimitProxyModel {
-                sourceModel: RecentlyInstalledProxyModel
+                // TODO removing sourceModel's binding
+                property var holder: RecentlyInstalledProxyModel
+                sourceModel: holder
                 maxRowCount: 4
             }
 

--- a/src/models/recentlyinstalledproxymodel.cpp
+++ b/src/models/recentlyinstalledproxymodel.cpp
@@ -11,6 +11,9 @@
 RecentlyInstalledProxyModel::RecentlyInstalledProxyModel(QObject *parent)
     : QSortFilterProxyModel(parent)
 {
+    setSourceModel(&AppsModel::instance());
+
+    sort(0, Qt::DescendingOrder);
 }
 
 bool RecentlyInstalledProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
@@ -36,11 +39,4 @@ bool RecentlyInstalledProxyModel::lessThan(const QModelIndex &source_left, const
     int rightTime = source_right.data(AppItem::InstalledTimeRole).toLongLong();
 
     return leftTime < rightTime;
-}
-
-void RecentlyInstalledProxyModel::componentComplete()
-{
-    setSourceModel(&AppsModel::instance());
-
-    sort(0, Qt::DescendingOrder);
 }

--- a/src/models/recentlyinstalledproxymodel.h
+++ b/src/models/recentlyinstalledproxymodel.h
@@ -6,12 +6,10 @@
 
 #include <QtQml/qqml.h>
 #include <QSortFilterProxyModel>
-#include <QQmlParserStatus>
 
-class RecentlyInstalledProxyModel : public QSortFilterProxyModel, public QQmlParserStatus
+class RecentlyInstalledProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
     QML_NAMED_ELEMENT(RecentlyInstalledProxyModel)
     QML_SINGLETON
 public:
@@ -35,9 +33,4 @@ protected:
 
 private:
     explicit RecentlyInstalledProxyModel(QObject *parent = nullptr);
-
-    // QQmlParserStatus interface
-public:
-    void classBegin() override {}
-    void componentComplete() override;
 };


### PR DESCRIPTION
  RecentlyInstalledProxyModel is an singleton model, so it will
not execute componentComplete for QQmlParserStatus.
  We add a property to remove sourceModel's binding.
