### PR TITLE
refact: only specify fullscreen as dark theme

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,8 @@ int main(int argc, char* argv[])
     // workaround for https://github.com/linuxdeepin/dtk/issues/115
     qputenv("D_POPUP_MODE", "embed");
 
+    DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::DontSaveApplicationTheme, true);
+
     QGuiApplication app(argc, argv);
     Dtk::Core::DLogManager::registerConsoleAppender();
     Dtk::Core::DLogManager::registerFileAppender();

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -121,14 +121,10 @@ QtObject {
                 }
             }
 
-            // Window mode: follow system theme
-            ApplicationHelper.setPaletteType(ApplicationHelper.UnknownType)
             windowedFrame.setGeometry(x, y, width, height)
             windowedFrame.requestActivate()
         } else {
 //            root.visibility = Window.FullScreen
-            // Fullscreen mode: always assume dark theme
-            ApplicationHelper.setPaletteType(ApplicationHelper.DarkType)
             if (DesktopIntegration.environmentVariable("DDE_CURRENT_COMPOSITOR") !== "TreeLand") {
                 fullscreenFrame.setGeometry(Screen.virtualX, Screen.virtualY, Screen.width, Screen.height)
             } else {
@@ -250,6 +246,8 @@ QtObject {
         DWindow.enabled: !DebugHelper.useRegularWindow
         DWindow.enableSystemResize: false
         DWindow.enableSystemMove: false
+        // Fullscreen mode: always assume dark theme
+        DWindow.themeType: ApplicationHelper.DarkType
 
         onVisibleChanged: {
             if (visible) {


### PR DESCRIPTION
  it depends libdtk6declarative's runtime.
  reset dconfig's cache value by override file.
