### PR TITLE
fix: The icons for mode switching on the left side are hard to see when the wallpaper is dark

### DIFF
--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -110,12 +110,17 @@ FocusScope {
             visible: placeholderLabel.text !== "" && model.count <= 0
             anchors.centerIn: parent
 
-            DciIcon {
-                id: placeholderIcon
-                visible: name !== ""
-                sourceSize {
-                    width: 128
-                    height: width
+            Control {
+                id: control
+                DciIcon {
+                    id: placeholderIcon
+                    visible: name !== ""
+                    sourceSize {
+                        width: 128
+                        height: width
+                    }
+                    palette: DTK.makeIconPalette(control.palette)
+                    theme: DTK.toColorType(control.palette.window)
                 }
             }
 

--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -96,6 +96,8 @@ Control {
                         anchors.fill: parent
                         name: iconSource
                         sourceSize: Qt.size(parent.width, parent.height)
+                        palette: DTK.makeIconPalette(root.palette)
+                        theme: DTK.toColorType(root.palette.window)
                     }
                 }
             }

--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -39,6 +39,8 @@ Control {
                 anchors.horizontalCenter: parent.horizontalCenter
                 name: iconSource
                 sourceSize: Qt.size(36, 36)
+                palette: DTK.makeIconPalette(root.palette)
+                theme: DTK.toColorType(root.palette.window)
             }
 
             // as topMargin

--- a/qml/windowed/SearchResultView.qml
+++ b/qml/windowed/SearchResultView.qml
@@ -69,6 +69,8 @@ Control {
                 height: width
             }
             name: "search_no_result"
+            palette: DTK.makeIconPalette(control.palette)
+            theme: DTK.toColorType(control.palette.window)
         }
 
         Label {

--- a/qml/windowed/SideBar.qml
+++ b/qml/windowed/SideBar.qml
@@ -91,6 +91,8 @@ ColumnLayout {
                     width: parent.width
                     height: parent.height / 3 * 2
                     name: isFreeSort ? categorizedIcon("freeSort") : categorizedIcon(CategorizedSortProxyModel.categoryType)
+                    palette: D.DTK.makeIconPalette(title.palette)
+                    theme: D.DTK.toColorType(title.palette.window)
                 }
 
                 Item {
@@ -102,6 +104,8 @@ ColumnLayout {
                     rotation: 270
                     width: parent.width
                     height: parent.height / 3 * 1
+                    palette: D.DTK.makeIconPalette(title.palette)
+                    theme: D.DTK.toColorType(title.palette.window)
                 }
             }
         }


### PR DESCRIPTION
fix: The icons for mode switching on the left side are hard to see when the wallpaper is dark

 DciIcon does not automatically handle color palettes and themes
 Add processing code

Issue: https://github.com/linuxdeepin/developer-center/issues/7571