### PR TITLE
fix: reuse translation from SearchResultView

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -413,7 +413,7 @@ Control {
                 columns: 7
                 paddingColumns: 1
                 placeholderIcon: "search_no_result"
-                placeholderText: qsTranslate("WindowedFrame", "No search results")
+                placeholderText: qsTranslate("SearchResultView", "No search results")
                 placeholderIconSize: 256
                 model: delegateSearchResultModel
                 padding: 10


### PR DESCRIPTION
小窗口界面的原对应文案已经移到了 SearchResultView，全屏位置同步更新文案位置。

Issue: https://github.com/linuxdeepin/developer-center/issues/7631