### PR TITLE
fix: avoid input \0 to SearchEdit

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -480,7 +480,7 @@ Control {
     }
 
     Keys.onPressed: {
-        if (searchEdit.focus === false && !searchEdit.text && (event.text && !"\t ".includes(event.text))) {
+        if (searchEdit.focus === false && !searchEdit.text && (event.text && !"\t\0 ".includes(event.text))) {
             searchEdit.focus = true
             searchEdit.text = event.text
         }

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -134,7 +134,7 @@ Item {
     }
 
     Keys.onPressed: function (event) {
-        if (bottomBar.searchEdit.focus === false && !bottomBar.searchEdit.text && (event.text && !"\t ".includes(event.text))) {
+        if (bottomBar.searchEdit.focus === false && !bottomBar.searchEdit.text && (event.text && !"\t\0 ".includes(event.text))) {
             bottomBar.searchEdit.focus = true
             bottomBar.searchEdit.text = event.text
         } else if (bottomBar.searchEdit.focus === true) {


### PR DESCRIPTION
在奇怪的情况下，使用 Ctrl+Space 会输入 `\0` （即NULL）字符，这时不应当将其输入到搜索框内。

Issue: https://github.com/linuxdeepin/developer-center/issues/7630 Log: