### PR TITLE
feat: focus on app item when we do not have focus

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -484,9 +484,18 @@ Control {
     }
 
     Keys.onPressed: {
-        if (searchEdit.focus === false && !searchEdit.text && (event.text && !"\t\0 ".includes(event.text))) {
+        if (searchEdit.focus === false && !searchEdit.text && (event.text && !"\t\r\0 ".includes(event.text))) {
             searchEdit.focus = true
             searchEdit.text = event.text
+        } else if (baseLayer.focus === true) {
+            // the SearchEdit will catch the key event first, and events that it won't accept will then got here
+            switch (event.key) {
+            case Qt.Key_Up:
+            case Qt.Key_Down:
+            case Qt.Key_Enter:
+            case Qt.Key_Return:
+                pages.focus = true
+            }
         }
     }
 

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -134,10 +134,10 @@ Item {
     }
 
     Keys.onPressed: function (event) {
-        if (bottomBar.searchEdit.focus === false && !bottomBar.searchEdit.text && (event.text && !"\t\0 ".includes(event.text))) {
+        if (bottomBar.searchEdit.focus === false && !bottomBar.searchEdit.text && (event.text && !"\t\r\0 ".includes(event.text))) {
             bottomBar.searchEdit.focus = true
             bottomBar.searchEdit.text = event.text
-        } else if (bottomBar.searchEdit.focus === true) {
+        } else if (bottomBar.searchEdit.focus === true || baseLayer.focus === true) {
             // the SearchEdit will catch the key event first, and events that it won't accept will then got here
             switch (event.key) {
             case Qt.Key_Up:


### PR DESCRIPTION
当无键盘焦点（实际是键盘焦点位于根节点组件）时，支持使用回车/方向键切换焦点到应用区域。

Issue: https://github.com/linuxdeepin/developer-center/issues/7244