### PR TITLE
fix: close menu when scrolling the app listview

### DIFF
--- a/qml/windowed/AppList.qml
+++ b/qml/windowed/AppList.qml
@@ -41,6 +41,8 @@ ColumnLayout {
         id: categoryListView
         AppListView {
             id: appCategoryListView
+
+            MouseAreaCom {}
         }
     }
 
@@ -52,6 +54,20 @@ ColumnLayout {
             onFolderClicked: {
                 freeSortViewFolderClicked(folderId, folderName)
             }
+
+            MouseAreaCom {}
+        }
+    }
+
+    component MouseAreaCom: MouseArea {
+        anchors.fill: parent
+
+        propagateComposedEvents: true
+        acceptedButtons: Qt.NoButton
+
+        onWheel: {
+            closeContextMenu()
+            wheel.accepted = false
         }
     }
 }


### PR DESCRIPTION
fix not close the menu when scrolling the app listview

Log: close the menu when scrolling mouse
Influence: close the menu when scrolling mouse
Issus: https://github.com/linuxdeepin/developer-center/issues/7646