### PR TITLE
fix: drag item cannot create a new page

### DIFF
--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -108,6 +108,18 @@ void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const 
     });
 }
 
+// return new empty page index
+int ItemArrangementProxyModel::creatEmptyPage() const
+{
+    m_topLevel->appendEmptyPage();
+    return m_topLevel->pageCount() - 1;
+}
+
+void ItemArrangementProxyModel::removeEmptyPage() const
+{
+    m_topLevel->removeEmptyPages();
+}
+
 QVariant ItemArrangementProxyModel::data(const QModelIndex &index, int role) const
 {
     int idx = index.row() - AppsModel::instance().rowCount();

--- a/src/models/itemarrangementproxymodel.h
+++ b/src/models/itemarrangementproxymodel.h
@@ -50,6 +50,8 @@ public:
     Q_INVOKABLE int pageCount(int folderId = 0) const;
     Q_INVOKABLE void updateFolderName(int folderId, const QString & name);
     Q_INVOKABLE void commitDndOperation(const QString & dragId, const QString & dropId, const DndOperation op, int pageHint = -1);
+    Q_INVOKABLE int creatEmptyPage() const;
+    Q_INVOKABLE void removeEmptyPage() const;
 
     // QAbstractItemModel interface
 public:

--- a/src/models/itemspage.cpp
+++ b/src/models/itemspage.cpp
@@ -67,6 +67,13 @@ QStringList ItemsPage::firstNItems(int count)
     return result;
 }
 
+void ItemsPage::appendEmptyPage()
+{
+    m_pages.append(QStringList());
+
+    emit pageCountChanged();
+}
+
 // if length of items larger than max item count per page, there will be another page get appended
 void ItemsPage::appendPage(const QStringList items)
 {

--- a/src/models/itemspage.h
+++ b/src/models/itemspage.h
@@ -30,6 +30,7 @@ public:
     QStringList firstNItems(int count = 4);
     QStringList allArrangedItems() const;
 
+    void appendEmptyPage();
     void appendPage(const QStringList items);
     void appendItem(const QString id, int page = -1);
     void insertItem(const QString id, int page, int pos = 0);


### PR DESCRIPTION
drag the item from the last page to the right to create a new page

Log: fix drag item cannot create a new page
Issues: https://github.com/linuxdeepin/developer-center/issues/7633
Influence: drag item can create a new page