### PR TITLE
fix: When using the TAB key to navigate to an application in the list…

### DIFF
--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -40,6 +40,13 @@ Item {
             }
         }
 
+        onActiveFocusChanged: {
+            if (activeFocus) {
+                listView.currentIndex = 0
+                listView.positionViewAtIndex(listView.currentIndex, 0)
+            }
+        }
+
         ScrollBar.vertical: ScrollBar { }
 
         model: freeSortProxyModel


### PR DESCRIPTION
…, the scrolling does not automatically occur to the first application.

      When the focus is activated, the default item is the first application.

    Issue: https://github.com/linuxdeepin/developer-center/issues/7684