### PR TITLE
fix: moving the last one item not remove empty page

### DIFF
--- a/src/models/itemspage.cpp
+++ b/src/models/itemspage.cpp
@@ -147,7 +147,16 @@ void ItemsPage::moveItemPosition(int fromPage, int fromIndex, int toPage, int to
         toIndex += 1;
     }
 
+    bool needRemoveEmptyPage = false;
+    if (m_pages[fromPage].count() == 1) {
+        needRemoveEmptyPage = true;
+    }
+
     moveItem(fromPage, fromIndex, toPage, toIndex);
+
+    if (needRemoveEmptyPage) {
+        removeEmptyPages();
+    }
 }
 
 bool ItemsPage::removeItem(const QString id, bool removePageIfPageIsEmpty)

--- a/tests/itemspagetest.cpp
+++ b/tests/itemspagetest.cpp
@@ -11,6 +11,7 @@ class TestItemsPage: public QObject
     Q_OBJECT
 private slots:
     void insertAndRemove();
+    void autoRemoveEmptyPage();
 };
 
 void TestItemsPage::insertAndRemove()
@@ -28,6 +29,21 @@ void TestItemsPage::insertAndRemove()
     QCOMPARE(ip.items(1), QStringList({"c", "d", "e"}));
     ip.removeItem("d");
     QCOMPARE(ip.items(1), QStringList({"c", "e"}));
+}
+
+void TestItemsPage::autoRemoveEmptyPage()
+{
+    ItemsPage ip(4);
+    ip.appendPage({"1", "2", "3"});
+    ip.appendPage({"4"});
+    ip.appendPage({"5", "6", "7"});
+
+    ip.moveItemPosition(1, 0, 2, 1, true);
+    QVERIFY(ip.pageCount() == 2);
+
+    ip.appendPage({"8"});
+    ip.moveItemPosition(2, 0, 0, 1, true);
+    QVERIFY(ip.pageCount() == 2);
 }
 
 QTEST_MAIN(TestItemsPage)


### PR DESCRIPTION
Dragging the last item on the last page will not delete the empty page

Log: moving the last one item not remove empty page
Influence: auto remove empty page