### PR TITLE
chore(CI): remove debian sid obs build

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -16,13 +16,6 @@ test_build:
               - x86_64
               - aarch64
 
-          - name: debian
-            paths:
-              - target_project: deepin:CI
-                target_repository: debian_sid
-            architectures:
-              - x86_64
-
           - name: archlinux
             paths:
               - target_project: deepin:CI


### PR DESCRIPTION
debian sid 的 Qt 版本过低，以及一些别的问题，导致 debian 构建现阶段无法通过。故目前移除处理。

Log: