### PR TITLE
chore: also hide fullscreen frame when lost focus

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -255,6 +255,18 @@ QtObject {
             }
         }
 
+        onActiveChanged: {
+            if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "FullscreenFrame")) {
+                // When composting is disabled, switching mode from fullscreen to windowed mode will cause window
+                // activeChanged signal get emitted. We reused the delay timer here to avoid the window get hide
+                // caused by that.
+                // Issue: https://github.com/linuxdeepin/developer-center/issues/6818
+                if (!LauncherController.shouldAvoidHideOrActive()) {
+                    LauncherController.hideWithTimer()
+                }
+            }
+        }
+
         Loader {
             anchors.fill: parent
             focus: true


### PR DESCRIPTION
全屏失去焦点时也隐藏启动器。

Issue: https://github.com/linuxdeepin/developer-center/issues/7635