### PR TITLE
feat: press enter to open the 1st result

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -499,15 +499,14 @@ Control {
             Keys.onReturnPressed: {
                 if (searchEdit.text === "") {
                     pages.focus = true
-                    // TODO: ensure the first one is actually selected?
                 } else {
-                    searchResultGridViewContainer.focus = true
-                    // TODO: ensure the first one is actually selected?
+                    searchResultGridViewContainer.currentItem?.onItemClicked()
                 }
             }
             onTextChanged: {
-//            console.log(text)
                 SearchFilterProxyModel.setFilterRegularExpression(text.trim())
+                // this can help indirectly reset the currentIndex of the view that the model is attached to
+                SearchFilterProxyModel.invalidate()
             }
         }
     }

--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -30,6 +30,8 @@ FocusScope {
     property alias cellHeight: item.cellHeight
     property alias cellWidth: item.cellWidth
 
+    readonly property alias currentIndex: gridView.currentIndex
+    readonly property alias currentItem: gridView.currentItem
     readonly property alias gridViewWidth: gridView.width
 
     function setPreviousPageSwitch(state) {

--- a/qml/windowed/GridViewContainer.qml
+++ b/qml/windowed/GridViewContainer.qml
@@ -30,6 +30,7 @@ FocusScope {
     property real cellHeight: 74
     property real cellWidth: 80
 
+    readonly property alias currentItem: gridView.currentItem
     readonly property alias gridViewWidth: gridView.width
     property alias highlight: gridView.highlight
 

--- a/qml/windowed/SearchResultView.qml
+++ b/qml/windowed/SearchResultView.qml
@@ -18,6 +18,10 @@ Control {
         searchResultViewContainer.focus = true
     }
 
+    function launchCurrentItem() {
+        searchResultViewContainer.currentItem?.onItemClicked()
+    }
+
     function positionViewAtBeginning() {
         searchResultViewContainer.positionViewAtBeginning()
     }

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -151,9 +151,15 @@ Item {
             switch (event.key) {
             case Qt.Key_Up:
             case Qt.Key_Down:
+                appGridLoader.item.forceActiveFocus()
+                return;
             case Qt.Key_Enter:
             case Qt.Key_Return:
-                appGridLoader.item.forceActiveFocus()
+                if (bottomBar.searchEdit.text !== "") {
+                    appGridLoader.item.launchCurrentItem()
+                } else {
+                    appGridLoader.item.forceActiveFocus()
+                }
             }
         }
     }


### PR DESCRIPTION
行为调整，当正在搜索时，回车将直接启动结果中被选中的结果（即第一个结果），而不再是将焦点移到搜索区域。注意，当前实现仍与4/9讨论的预期行为不同，预期是希望搜索过程中也始终显示选中项，即搜索结果区域无焦点时，选中项也有一个近似于hover效果的指示效果的。

未在搜索时的行为不变（即，如果焦点在搜索框但没输入任何关键词就按下回车，此时会将焦点切换到应用区域）。
