### PR TITLE
fix: The hover background of the app icon overlaps with the separator…

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -203,7 +203,7 @@ Popup {
 
                 PageIndicator {
                     Layout.alignment: Qt.AlignHCenter
-
+                    visible: folderPagesView.count > 1 ? true : false
                     id: folderPageIndicator
                     implicitHeight: isWindowedMode ? 13 : folderPageIndicator.implicitWidth
                     count: folderPagesView.count

--- a/qml/windowed/GridViewContainer.qml
+++ b/qml/windowed/GridViewContainer.qml
@@ -27,7 +27,7 @@ FocusScope {
     property int rows: Math.min(Math.ceil(count * 1.0 / columns), Helper.windowed.maxViewRows)
     property int paddingColumns: Helper.frequentlyUsed.cellPaddingColumns
     property int paddingRows: Helper.frequentlyUsed.cellPaddingRows
-    property real cellHeight: 74
+    property real cellHeight: 72
     property real cellWidth: 80
 
     readonly property alias gridViewWidth: gridView.width


### PR DESCRIPTION
… line in the recent installations display.

Adjust the spacing between GridView items, and update the page indicator display rules.

Log:
Influence:
Issue: https://github.com/linuxdeepin/developer-center/issues/7782