### PR TITLE
fix: mini mode window margin not set

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -118,7 +118,7 @@ QRect DesktopIntegration::dockGeometry() const
 
 uint DesktopIntegration::dockSpacing() const
 {
-    return m_dockIntegration->windowMargin();
+    return 10;
 }
 
 QString DesktopIntegration::backgroundUrl() const
@@ -220,7 +220,6 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
 
     connect(m_dockIntegration, &DdeDock::directionChanged, this, &DesktopIntegration::dockPositionChanged);
     connect(m_dockIntegration, &DdeDock::geometryChanged, this, &DesktopIntegration::dockGeometryChanged);
-    connect(m_dockIntegration, &DdeDock::windowMarginChanged, this, &DesktopIntegration::dockSpacingChanged);
     connect(m_appearanceIntegration, &Appearance::wallpaperBlurhashChanged, this, &DesktopIntegration::backgroundUrlChanged);
     connect(m_appearanceIntegration, &Appearance::opacityChanged, this, &DesktopIntegration::opacityChanged);
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -100,23 +100,23 @@ QtObject {
 
             let dockGeometry = descaledRect(DesktopIntegration.dockGeometry)
             if (dockGeometry.width > 0 && dockGeometry.height > 0) {
-//                console.log(114514, dockGeometry)
+                let dockSpacing = DesktopIntegration.dockSpacing
                 switch (DesktopIntegration.dockPosition) {
                 case Qt.DownArrow:
-                    x = dockGeometry.left
-                    y = (dockGeometry.top >= 0 ? dockGeometry.top : (Screen.height - dockGeometry.height)) - height - DesktopIntegration.dockSpacing
+                    x = dockGeometry.left + dockSpacing
+                    y = (dockGeometry.top >= 0 ? dockGeometry.top : (Screen.height - dockGeometry.height)) - height - dockSpacing
                     break
                 case Qt.LeftArrow:
-                    x = dockGeometry.right + DesktopIntegration.dockSpacing
-                    y = (dockGeometry.top >= 0 ? dockGeometry.top : 0)
+                    x = dockGeometry.right + dockSpacing
+                    y = (dockGeometry.top >= 0 ? dockGeometry.top : 0) + dockSpacing
                     break
                 case Qt.UpArrow:
-                    x = dockGeometry.left
-                    y = dockGeometry.bottom + DesktopIntegration.dockSpacing
+                    x = dockGeometry.left + dockSpacing
+                    y = dockGeometry.bottom + dockSpacing
                     break
                 case Qt.RightArrow:
-                    x = (dockGeometry.left >= 0 ? dockGeometry.left : (Screen.width - dockGeometry.width)) - width - DesktopIntegration.dockSpacing
-                    y = dockGeometry.top
+                    x = (dockGeometry.left >= 0 ? dockGeometry.left : (Screen.width - dockGeometry.width)) - width - dockSpacing
+                    y = dockGeometry.top + dockSpacing
                     break
                 }
             }

--- a/src/ddeintegration/ddedock.cpp
+++ b/src/ddeintegration/ddedock.cpp
@@ -16,15 +16,12 @@ DdeDock::DdeDock(QObject *parent)
                                       QDBusConnection::sessionBus(), this))
     , m_direction(Qt::DownArrow)
     , m_rect(QRect(-1, -1, 0, 0))
-    , m_windowMargin(0)
 {
     QTimer::singleShot(0, this, &DdeDock::updateDockRectAndPositionFromDBus);
-    QMetaObject::invokeMethod(this, &DdeDock::updateDockWindowMarginFromDBus, Qt::QueuedConnection);
 
     // Due to current dde-dock bug, we need to do both since position changed signal might not got emit in some case.
     connect(m_dbusDaemonDockIface, &Dock1::PositionChanged, this, &DdeDock::updateDockRectAndPositionFromDBus);
     connect(m_dbusDaemonDockIface, &Dock1::FrontendWindowRectChanged, this, &DdeDock::updateDockRectAndPositionFromDBus);
-    connect(m_dbusDaemonDockIface, &Dock1::WindowMarginChanged, this, &DdeDock::updateDockWindowMarginFromDBus);
 }
 
 DdeDock::~DdeDock()
@@ -40,11 +37,6 @@ Qt::ArrowType DdeDock::direction() const
 QRect DdeDock::geometry() const
 {
     return m_rect;
-}
-
-uint DdeDock::windowMargin() const
-{
-    return m_windowMargin;
 }
 
 bool DdeDock::isDocked(const QString &desktop) const
@@ -105,12 +97,6 @@ void DdeDock::updateDockPositionFromDBus()
         m_direction = newDirection;
         emit directionChanged();
     }
-}
-
-void DdeDock::updateDockWindowMarginFromDBus()
-{
-    m_windowMargin = m_dbusDaemonDockIface->windowMargin();
-    emit windowMarginChanged();
 }
 
 void DdeDock::updateDockRectFromDBus()

--- a/src/ddeintegration/ddedock.h
+++ b/src/ddeintegration/ddedock.h
@@ -14,7 +14,6 @@ class DdeDock : public QObject
 
     Q_PROPERTY(Qt::ArrowType direction READ direction NOTIFY directionChanged)
     Q_PROPERTY(QRect geometry READ geometry NOTIFY geometryChanged)
-    Q_PROPERTY(uint windowMargin READ windowMargin NOTIFY windowMarginChanged)
 
 public:
     explicit DdeDock(QObject *parent = nullptr);
@@ -22,7 +21,6 @@ public:
 
     Qt::ArrowType direction() const;
     QRect geometry() const;
-    uint windowMargin() const;
 
     bool isDocked(const QString & desktop) const;
     void sendToDock(const QString & desktop, int idx = -1);
@@ -31,17 +29,14 @@ public:
 signals:
     void directionChanged();
     void geometryChanged();
-    void windowMarginChanged();
 
 private:
     void updateDockRectAndPositionFromDBus();
     void updateDockPositionFromDBus();
-    void updateDockWindowMarginFromDBus();
     void updateDockRectFromDBus();
 
     __Dock1 * m_dbusDaemonDockIface;
 
     Qt::ArrowType m_direction;
     QRect m_rect;
-    uint m_windowMargin;
 };


### PR DESCRIPTION
dock doesn't have space margin, so just use 10px.

Issue: https://github.com/linuxdeepin/developer-center/issues/7781

<img width="329" alt="image" src="https://github.com/linuxdeepin/dde-launchpad/assets/12298476/9c36b862-5b63-4190-87a3-76d289b502eb">
