### PR TITLE
fix: fix dragging an item into folder causes crash

### DIFF
--- a/src/models/itemspage.cpp
+++ b/src/models/itemspage.cpp
@@ -138,6 +138,10 @@ void ItemsPage::insertItem(const QString id, int page, int pos)
 
 void ItemsPage::insertItemToPage(const QString &id, int toPage)
 {
+    Q_ASSERT(toPage < m_pages.count());
+
+    if (toPage < 0) toPage = qMax(m_pages.count() - 1, 0);
+
     insertItem(id, toPage, m_pages[toPage].count());
 }
 


### PR DESCRIPTION
dragging an item into folder, toPageIndex is -1, need to recalculate.

Log: fix dragging an item into folder causes crash
Influence: dragging item into folder