### PR TITLE
fix: In full-screen mode, the display effect of the application group…

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -17,7 +17,7 @@ Popup {
 
     property alias currentFolderId: folderLoader.currentFolderId
     property alias folderName: folderLoader.folderName
-    property var folderNameFont: DTK.fontManager.t3
+    property var folderNameFont: DTK.fontManager.t2
     readonly property bool isWindowedMode: LauncherController.currentFrame === "WindowedFrame"
 
     modal: true
@@ -70,11 +70,10 @@ Popup {
                 SystemPalette { id: folderTextPalette }
                 TextInput {
                     Layout.fillWidth: true
-
                     font: folderNameFont
                     horizontalAlignment: Text.AlignHCenter
                     text: folderLoader.folderName
-                    color: folderTextPalette.text
+                    color: palette.text
                     onEditingFinished: {
                         ItemArrangementProxyModel.updateFolderName(folderLoader.currentFolderId, text);
                     }
@@ -124,6 +123,7 @@ Popup {
                                         id: fullScreenGridViewContainer
                                         GridViewContainer {
                                             id: folderGridViewContainer
+                                            objectName: "folderGridViewContainer"
                                             anchors.fill: parent
                                             rows: 3
                                             columns: 4

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -331,6 +331,7 @@ Control {
 
                             GridViewContainer {
                                 id: gridViewContainer
+                                objectName: "gridViewContainer"
                                 anchors.fill: parent
                                 rows: 4
                                 columns: 7

--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -64,7 +64,12 @@ FocusScope {
         property int cellWidth: cellHeight
         Rectangle {
             anchors.centerIn: parent
-            width: item.cellWidth * root.columns
+            width: {
+                if (root.objectName === "folderGridViewContainer")
+                    return model.rowCount() > root.columns - 1 ? item.cellWidth * root.columns : model.rowCount() * item.cellWidth
+                else
+                    return item.cellWidth * root.columns
+            }
             height: rows == 0 ? parent.height : (item.cellHeight * root.rows)
             color: "transparent"
 


### PR DESCRIPTION
… does not match the design.

Modify the display logic of the application group in full-screen mode. Remove the application group when there is only one application in the group. Modify the font and color of the application group title.

Log:
Influence:
Issue: https://github.com/linuxdeepin/developer-center/issues/7788