### PR TITLE
fix: Imcomplete display application name under 2.0 scale ratio on 2K …

### DIFF
--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -105,7 +105,7 @@ Control {
             // as topMargin
             Item {
                 width: 1
-                height: isWindowedMode ? 5 : 20
+                height: isWindowedMode ? 5 : root.height / 10
             }
 
             Label {


### PR DESCRIPTION
…screen

Scale icon and application name padding with gridview size rather than fixed point size

Issue: https://github.com/linuxdeepin/developer-center/issues/7639
Log: Imcomplete display application name under 2.0 scale ratio on 2K screen