### PR TITLE
fix: uninstallDialog doesn't center in screen

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -325,6 +325,8 @@ QtObject {
         property string appId: ""
         property string appName: ""
 
+        DLayerShellWindow.anchors: DLayerShellWindow.AnchorNone
+
         minimumWidth: layout.implicitWidth + 2 * DS.Style.dialogWindow.contentHMargin
         minimumHeight: layout.implicitHeight + DS.Style.dialogWindow.titleBarHeight
         maximumWidth: minimumWidth


### PR DESCRIPTION
I don't know why it exists when org.deepin.ds.dock is loaded with
the org.deepin.ds.launchpad.
Using layershell to anchor the window's position.

issue: https://github.com/linuxdeepin/developer-center/issues/7824
