### PR TITLE
fix: should clip app folder name text

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -69,6 +69,7 @@ Popup {
                 SystemPalette { id: folderTextPalette }
                 TextInput {
                     Layout.fillWidth: true
+                    clip: true
                     font: folderNameFont
                     horizontalAlignment: Text.AlignHCenter
                     text: folderLoader.folderName


### PR DESCRIPTION
应用文件夹的显示名称需要 clip 以免被显示到外面。

Issue: linuxdeepin/developer-center#7949
Log: