### PR TITLE
fix: FTBFS on Archlinux caused by CMake CMP0071

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.10)
 
 if(NOT DEFINED VERSION)
     set(VERSION 0.6.0)


### PR DESCRIPTION
由于 CMP0071，CMake 的 AUTOMOC 跳过了一些生成的 CPP 文件的处理，例如
launcher-qml-windowed_org_deepin_launchpad_windowedPlugin.cpp。我们 直接提高 CMake 最小版本来处理此问题。

Log: