### PR TITLE
fix: can drag item when folderGridViewPopup is open

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -400,7 +400,7 @@ Control {
                                     IconItemDelegate {
                                         id: iconItemDelegate
                                         anchors.fill: parent
-                                        dndEnabled: true
+                                        dndEnabled: !folderGridViewPopup.opened
                                         Drag.mimeData: {
                                             "text/x-dde-launcher-dnd-desktopId": model.desktopId
                                         }


### PR DESCRIPTION
prohibit drag when expanding folders

Issue: https://github.com/linuxdeepin/developer-center/issues/7926