### PR TITLE
chore(UI): section header spacing from 8 to 6

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -58,7 +58,7 @@ Item {
             required property string section
             width: parent.width
             Rectangle {
-                height: 8
+                height: 6
                 width: parent.width
                 color: "transparent"
                 visible: {


### PR DESCRIPTION
设计核对，将分类列表的 section header 与 item 的间距高度从 8 调整至
6。

Issue: linuxdeepin/developer-center#7938
Log: