### PR TITLE
fix: useless refresh for app icons

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char* argv[])
     qputenv("D_POPUP_MODE", "embed");
 
     DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::DontSaveApplicationTheme, true);
+    DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::UseInactiveColorGroup, false);
 
     QGuiApplication app(argc, argv);
     Dtk::Core::DLogManager::registerConsoleAppender();

--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -67,7 +67,7 @@ Control {
             }
 
             Item {
-                width: isWindowedMode ? 36 : parent.width / 2
+                width: parent.width / 2
                 height: width
                 anchors.horizontalCenter: parent.horizontalCenter
 
@@ -97,7 +97,7 @@ Control {
                         name: iconSource
                         sourceSize: Qt.size(parent.width, parent.height)
                         palette: DTK.makeIconPalette(root.palette)
-                        theme: DTK.toColorType(root.palette.window)
+                        theme: ApplicationHelper.DarkType
                     }
                 }
             }


### PR DESCRIPTION
Don't use inactive palette group and don't change width and height when switching from windowed to fullscreen.

Log: fix useless refresh for app icons
Issue: https://github.com/linuxdeepin/developer-center/issues/7826
Depends: https://github.com/linuxdeepin/dtkdeclarative/pull/319