### PR TITLE
fix: avoid render glitch icon when name is empty

### DIFF
--- a/src/quick/launcherfoldericonprovider.cpp
+++ b/src/quick/launcherfoldericonprovider.cpp
@@ -51,6 +51,7 @@ QPixmap LauncherFolderIconProvider::requestPixmap(const QString &id, QSize *size
         int curRow = curIdx / iconPerRow;
         int curCol = curIdx % iconPerRow;
         QPixmap iconPixmap(QSize(iconSize, iconSize));
+        iconPixmap.fill(Qt::transparent);
         IconUtils::getThemeIcon(iconPixmap, icon, iconSize);
         QRect iconRect;
         iconRect.setTop(padding + curRow * (iconSize + iconSpacing));


### PR DESCRIPTION
避免在无图标名时，渲染未填充 QPixmap 导致的 glitch 掉的图标。

Log: