### PR TITLE
chore: only use normal state for dci icons

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -180,6 +180,7 @@ Item {
                 text: model.display
                 checkable: false
                 icon.name: (iconName && iconName !== "") ? iconName : "application-x-desktop"
+                DciIcon.mode: DTK.NormalState
                 font: DTK.fontManager.t8
                 palette.windowText: parent.palette.brightText
                 anchors.fill: parent

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -132,6 +132,7 @@ Item {
                 text: model.display.startsWith("internal/category/") ? getCategoryName(model.display.substring(18)) : model.display
                 checkable: false
                 icon.name: iconName === undefined ? "folder-icon" : iconName
+                DciIcon.mode: DTK.NormalState
                 anchors.fill: parent
                 anchors.leftMargin: 10
                 anchors.rightMargin: 10


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/8050