### PR TITLE
fix: check MIME before accepting drop

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -228,7 +228,8 @@ Control {
                 onPositionChanged: {
                     checkDragMove()
                 }
-                onDropped: {
+                onDropped: (drop) => {
+                    if (!drop.keys.includes("text/x-dde-launcher-dnd-desktopId")) return;
                     // drop into current page
                     let dragId = drop.getDataAsString("text/x-dde-launcher-dnd-desktopId")
                     dropOnPage(dragId, "internal/folders/0", pages.currentIndex)

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -85,6 +85,7 @@ Item {
             }
 
             onPositionChanged: function(drag) {
+                if (!drag.keys.includes("text/x-dde-launcher-dnd-desktopId")) return;
                 let dragId = drag.getDataAsString("text/x-dde-launcher-dnd-desktopId")
                 if (dragId === desktopId) {
                     return
@@ -110,6 +111,7 @@ Item {
             }
 
             onDropped: function(drop) {
+                if (!drop.keys.includes("text/x-dde-launcher-dnd-desktopId")) return;
                 drop.accept()
                 let dragId = drop.getDataAsString("text/x-dde-launcher-dnd-desktopId")
                 showDropIndicator = false

--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -46,6 +46,12 @@ void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const 
     std::tuple<int, int, int> dragOrigPos = findItem(dragId);
     std::tuple<int, int, int> dropOrigPos = findItem(dropId);
 
+    Q_ASSERT(std::get<0>(dragOrigPos) != -1);
+    if (std::get<0>(dragOrigPos) == -1) {
+        qWarning() << "Cannot found" << dragId << "in current item arrangement.";
+        return;
+    }
+
     if (op != DndOperation::DndJoin) {
         // move to dropId's front or back
         if (std::get<0>(dragOrigPos) == std::get<0>(dropOrigPos)) {


### PR DESCRIPTION
避免因接受任意的拖拽行为而导致崩溃，包括：

1. 松开（drop）时检查 MIME 是否与预期匹配，不匹配则直接返回
2. 尝试应用位置调整行为时，检查原始拖放的项目是否真实存在

Log: