### PR TITLE
fix: reserved padding for dock should be HiDPI aware

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -21,10 +21,13 @@ Control {
     focus: true
     objectName: "FullscreenFrame-BaseLayer"
 
-    leftPadding: (DesktopIntegration.dockPosition === Qt.LeftArrow ? DesktopIntegration.dockGeometry.width : 0)
-    rightPadding: (DesktopIntegration.dockPosition === Qt.RightArrow ? DesktopIntegration.dockGeometry.width : 0)
-    topPadding: (DesktopIntegration.dockPosition === Qt.UpArrow ? DesktopIntegration.dockGeometry.height : 0) + 20
-    bottomPadding: (DesktopIntegration.dockPosition === Qt.DownArrow ? DesktopIntegration.dockGeometry.height : 0) + 20
+    readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
+    readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
+
+    leftPadding: (DesktopIntegration.dockPosition === Qt.LeftArrow ? dockSpacing : 0)
+    rightPadding: (DesktopIntegration.dockPosition === Qt.RightArrow ? dockSpacing : 0)
+    topPadding: (DesktopIntegration.dockPosition === Qt.UpArrow ? dockSpacing : 0) + 20
+    bottomPadding: (DesktopIntegration.dockPosition === Qt.DownArrow ? dockSpacing : 0) + 20
 
     property Palette textColor: appTextColor
     palette.windowText: ColorSelector.textColor


### PR DESCRIPTION
全屏启动器 dock 预留的空白区域需要考虑高分屏缩放情况。dock 对应 dbus 提供的数值是缩放后的数值，所以需要除掉。
