### PR TITLE
fix: should allow drop on empty space

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -206,7 +206,8 @@ Control {
             DropArea {
                 id: dropArea
                 property int pageIntent: 0
-                property int horizontalPadding: searchResultGridViewContainer.cellWidth
+                readonly property real paddingColumns: 0.5
+                readonly property int horizontalPadding:  searchResultGridViewContainer.cellWidth * paddingColumns
                 anchors.fill: parent
 
                 property bool createdEmptyPage: false
@@ -234,6 +235,11 @@ Control {
                     checkDragMove()
                 }
                 onDropped: (drop) => {
+                    // drop over the left or right boundary of the page, do nothing
+                    if (pageIntent !== 0) {
+                        pageIntent = 0
+                        return
+                    }
                     // drop into current page
                     let dragId = drop.getDataAsString("text/x-dde-launcher-dnd-desktopId")
                     dropOnPage(dragId, "internal/folders/0", pages.currentIndex)

--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -76,7 +76,6 @@ void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const 
     } else {
         if (dragId.startsWith("internal/folders/") && dropId != "internal/folders/0") return; // cannot drag folder onto something
         if (std::get<0>(dropOrigPos) != 0 && dropId != "internal/folders/0") return; // folder inside folder is not allowed
-        if (dropId.startsWith("internal/folders/") && std::get<1>(dragOrigPos) == pageHint) return; // drop on same page
 
         // the source item will be inside a new folder anyway.
         const int srcFolderId = std::get<0>(dragOrigPos);


### PR DESCRIPTION
允许拖拽到空白区域。

根据追溯，之前屏蔽当前页面drop item的原因是避免鼠标拖拽到屏幕两侧并
在未触发翻页的情况下即释放鼠标（此时应当什么也不做，使应用归位）。
此逻辑致使无法将item拖拽到当前页面最后的空白位置，也误伤了非同一文件
夹但在同一页面的情况。

Issue: linuxdeepin/developer-center#7640
Log: