### PR TITLE
fix: show single line when font is too large to show two lines

### DIFF
--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -115,6 +115,7 @@ Control {
             }
 
             Label {
+                property bool singleRow: isWindowedMode && (font.pixelSize > Helper.windowed.doubleRowMaxFontSize)
                 id: iconItemLabel
                 text: root.text
                 textFormat: Text.PlainText
@@ -122,11 +123,14 @@ Control {
                 leftPadding: 2
                 rightPadding: 2
                 horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.Wrap
+                wrapMode: singleRow ? Text.NoWrap : Text.Wrap
                 elide: Text.ElideRight
-                maximumLineCount: 2
+                maximumLineCount: singleRow ? 1 : 2
             }
         }
+        ToolTip.text: root.text
+        ToolTip.delay: 1000
+        ToolTip.visible: hovered
         background: ButtonPanel {
             button: parent
             outsideBorderColor: null


### PR DESCRIPTION
字太大，显示不下两行的情况下，显示一行，并增加 tooltip。

Issue: linuxdeepin/developer-center#8239
Log: