### PR TITLE
fix: padding error in large font

### DIFF
--- a/qml/windowed/BottomBar.qml
+++ b/qml/windowed/BottomBar.qml
@@ -45,6 +45,7 @@ Control {
 
             contentItem: SearchEdit {
                 id: searchEdit
+                padding: 1
                 property Palette iconPalette: Palette {
                     normal {
                         crystal: Qt.rgba(0, 0, 0, 1)


### PR DESCRIPTION
Use a smaller padding for search edit because when use the largest font, the text might be clipped.

Log: fix padding error in large font
Issue: https://github.com/linuxdeepin/developer-center/issues/8295