### PR TITLE
fix: List's item is not centered

### DIFF
--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -12,6 +12,7 @@ QtObject {
         property int bottomBarMargins: 10
         property int maxViewRows: 4
         property int doubleRowMaxFontSize: 12
+        property int listItemHeight: 36
     }
     property QtObject frequentlyUsed :QtObject {
         property int leftMargin: 10

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -221,6 +221,8 @@ FocusScope {
                 }
 
                 background: ItemBackground {
+                    implicitWidth: DStyle.Style.itemDelegate.width
+                    implicitHeight: Helper.windowed.listItemHeight
                     button: itemDelegate
                 }
             }

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -6,6 +6,7 @@ import QtQuick 2.15
 import QtQml.Models 2.15
 import QtQuick.Controls 2.15 as QQC2
 import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DStyle
 
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
@@ -151,6 +152,8 @@ Item {
 
                 background: ItemBackground {
                     id: bg
+                    implicitWidth: DStyle.Style.itemDelegate.width
+                    implicitHeight: Helper.windowed.listItemHeight
                     button: itemDelegate
                 }
 


### PR DESCRIPTION
Item's implicitHeight is not high enough, and it's height doesn't
match the design drawing.
TODO: it's a bug for dtk, but it doesn't relay on dtk.

Issue: https://github.com/linuxdeepin/developer-center/issues/8361
