### PR TITLE
fix: folder icon not change with theme

### DIFF
--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -132,7 +132,7 @@ Item {
                 id: itemDelegate
                 text: model.display.startsWith("internal/category/") ? getCategoryName(model.display.substring(18)) : model.display
                 checkable: false
-                icon.name: iconName === undefined ? "folder-icon" : iconName
+                icon.name: iconName === undefined ? "folder" : iconName
                 DciIcon.mode: DTK.NormalState
                 anchors.fill: parent
                 anchors.leftMargin: 10


### PR DESCRIPTION
folder-icon does not exist in all themes, replace it with folder.

Log: fix folder icon not change with theme
Issue: https://github.com/linuxdeepin/developer-center/issues/8343