### PR TITLE
fix: Launchpad crashes.

### DIFF
--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -80,17 +80,20 @@ void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const 
         // the source item will be inside a new folder anyway.
         const int srcFolderId = std::get<0>(dragOrigPos);
         ItemsPage * srcFolder = folderById(srcFolderId);
-        srcFolder->removeItem(dragId);
 
         if (dropId.startsWith("internal/folders/")) {
             // drop into existing folder
             const int dropOrigFolder = QStringView{dropId}.mid(17).toInt();
             ItemsPage * dstFolder = folderById(dropOrigFolder);
+            if (srcFolder == dstFolder && srcFolder->itemCount() == 1)
+                return;
+            srcFolder->removeItem(dragId);
             if (srcFolder->pageCount() == 0 && srcFolder != dstFolder) {
                 removeFolder(QString::number(srcFolderId));
             }
             dstFolder->insertItemToPage(dragId, pageHint);
         } else {
+            srcFolder->removeItem(dragId);
             // make a new folder, move two items into the folder
             QString dstFolderId = findAvailableFolderId();
             ItemsPage * dstFolder = createFolder(dstFolderId);

--- a/src/models/itemspage.cpp
+++ b/src/models/itemspage.cpp
@@ -239,6 +239,15 @@ QStringList ItemsPage::allArrangedItems() const
     return result;
 }
 
+int ItemsPage::itemCount() const 
+{
+    int count = 0;
+    for (const QStringList &pageItems : m_pages) {
+        count += pageItems.count();
+    }
+    return count;
+}
+
 // item will be moved to the index
 void ItemsPage::moveItem(int fromPage, int fromIndex, int toPage, int toIndex)
 {

--- a/src/models/itemspage.h
+++ b/src/models/itemspage.h
@@ -29,6 +29,7 @@ public:
     QStringList items(int page = 0);
     QStringList firstNItems(int count = 4);
     QStringList allArrangedItems() const;
+    int itemCount() const;
 
     void appendEmptyPage();
     void appendPage(const QStringList items);


### PR DESCRIPTION
When there is only one application in the group and it is dragged and dropped within the same group, the drag and drop process is not handled.

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/8384