### PR TITLE
fix: appItem without icon field clicking to start causing crash

### DIFF
--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -191,7 +191,7 @@ Control {
         TapHandler {
             acceptedButtons: Qt.LeftButton
             onTapped: {
-                if (root.icons) {
+                if (model.itemType === ItemArrangementProxyModel.FolderItemType) {
                     root.folderClicked()
                 } else {
                     root.itemClicked()
@@ -209,7 +209,7 @@ Control {
     background: DebugBounding { }
 
     Keys.onSpacePressed: {
-        if (root.icons !== undefined) {
+        if (model.itemType === ItemArrangementProxyModel.FolderItemType) {
             root.folderClicked()
         } else {
             root.itemClicked()
@@ -217,7 +217,7 @@ Control {
     }
 
     Keys.onReturnPressed: {
-        if (root.icons !== undefined) {
+        if (model.itemType === ItemArrangementProxyModel.FolderItemType) {
             root.folderClicked()
         } else {
             root.itemClicked()

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -133,7 +133,7 @@ Item {
                 id: itemDelegate
                 text: model.display.startsWith("internal/category/") ? getCategoryName(model.display.substring(18)) : model.display
                 checkable: false
-                icon.name: iconName === undefined ? "folder" : iconName
+                icon.name: itemType === ItemArrangementProxyModel.FolderItemType ? "folder" : iconName
                 DciIcon.mode: DTK.NormalState
                 anchors.fill: parent
                 anchors.leftMargin: 10
@@ -180,7 +180,7 @@ Item {
                         if (mouse.button === Qt.RightButton) {
                             showContextMenu(itemDelegate, model, false, false, false)
                         } else {
-                            if (!iconName) {
+                            if (itemType === ItemArrangementProxyModel.FolderItemType) {
                                 console.log("freesort view folder clicked:", desktopId);
                                 let idStr = model.desktopId
                                 let strFolderId = Number(idStr.replace("internal/folders/", ""))

--- a/src/models/appitem.cpp
+++ b/src/models/appitem.cpp
@@ -47,7 +47,7 @@ const QString AppItem::iconName() const
 
 void AppItem::setIconName(const QString &iconName)
 {
-    setData(iconName, AppItem::IconNameRole);
+    setData(iconName.isEmpty() ? "application-x-desktop" : iconName, AppItem::IconNameRole);
 }
 
 const QStringList AppItem::categories() const

--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -24,7 +24,12 @@ int ItemArrangementProxyModel::pageCount(int folderId) const
     QString fullId("internal/folders/" + QString::number(folderId));
     Q_ASSERT(m_folders.contains(fullId));
 
-    return m_folders.value(fullId)->pageCount();
+    if (auto itemPage = m_folders.value(fullId); itemPage) {
+        return itemPage->pageCount();
+    } else {
+        qWarning() << "itemPage is null, return 0. fullId is" << fullId;
+        return 0;
+    }
 }
 
 void ItemArrangementProxyModel::updateFolderName(int folderId, const QString &name)
@@ -149,6 +154,8 @@ QVariant ItemArrangementProxyModel::data(const QModelIndex &index, int role) con
                 return folder;
             case IconsNameRole:
                 return QVariant();
+            case ItemTypeRole:
+                return AppItemType;
         }
     } else {
         // a folder
@@ -181,9 +188,10 @@ QVariant ItemArrangementProxyModel::data(const QModelIndex &index, int role) con
                 }
                 return icons;//QStringList({"deepin-music"});
             }
+            case ItemTypeRole:
+                return FolderItemType;
         }
     }
-
     return QConcatenateTablesProxyModel::data(index, role);
 }
 
@@ -191,6 +199,7 @@ QHash<int, QByteArray> ItemArrangementProxyModel::roleNames() const
 {
     auto existingRoleNames = AppsModel::instance().roleNames();
     existingRoleNames.insert(IconsNameRole, QByteArrayLiteral("folderIcons"));
+    existingRoleNames.insert(ItemTypeRole, QByteArrayLiteral("itemType"));
     return existingRoleNames;
 }
 

--- a/src/models/itemarrangementproxymodel.h
+++ b/src/models/itemarrangementproxymodel.h
@@ -17,11 +17,18 @@ class ItemArrangementProxyModel : public QConcatenateTablesProxyModel
     QML_NAMED_ELEMENT(ItemArrangementProxyModel)
     QML_SINGLETON
 public:
+    enum ItemType{
+        AppItemType = 0,
+        FolderItemType = 1
+    };
+    Q_ENUM(ItemType)
+
     enum Roles {
         PageRole = AppsModel::ProxyModelExtendedRole,
         IndexInPageRole,
         FolderIdNumberRole,
-        IconsNameRole
+        IconsNameRole,
+        ItemTypeRole
     };
     Q_ENUM(Roles)
 


### PR DESCRIPTION
Show default icon when icon is empty, and add a field to distinguish between folders and appitems

Issue: https://github.com/linuxdeepin/developer-center/issues/8396