### PR TITLE
fix: two popup when right folder's popup item

### DIFF
--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -201,6 +201,7 @@ Control {
 
         TapHandler {
             acceptedButtons: Qt.RightButton
+            gesturePolicy: TapHandler.WithinBounds
             onTapped: {
                 root.menuTriggered()
             }


### PR DESCRIPTION
the tap gesture is not canceled default, it will trigger menu repeated.

Issue: https://github.com/linuxdeepin/developer-center/issues/8368
