### PR TITLE
fix: allow continue search when SearchEdit isn't focused

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -541,9 +541,13 @@ Control {
     }
 
     Keys.onPressed: {
-        if (searchEdit.focus === false && !searchEdit.text && (event.text && !"\t\r\0 ".includes(event.text))) {
+        if (searchEdit.focus === false && (event.text && !"\t\r\0 ".includes(event.text))) {
             searchEdit.focus = true
-            searchEdit.text = event.text
+            if (searchEdit.text) {
+                searchEdit.text += event.text
+            } else {
+                searchEdit.text = event.text
+            }
         } else if (baseLayer.focus === true) {
             // the SearchEdit will catch the key event first, and events that it won't accept will then got here
             switch (event.key) {


### PR DESCRIPTION
全屏启动器行为调整，搜索框无焦点时均允许按下字母键继续搜索，按下的键会追加到搜索框内。

（其实搜索内容为空时也可以是直接往后追加，这里避免后续有别的奇怪需求，暂且分成 if else 来写）

Issue: linuxdeepin/developer-center#7627