### PR TITLE
fix: When dragging any app and the last app to create an app folder, …

### DIFF
--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -109,8 +109,8 @@ void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const 
             if (srcFolder->pageCount() == 0 && srcFolder != m_topLevel) {
                 removeFolder(QString::number(srcFolderId));
             }
-            m_topLevel->removeItem(dropId);
             m_topLevel->insertItem(dstFolderId, std::get<1>(dropOrigPos), std::get<2>(dropOrigPos));
+            m_topLevel->removeItem(dropId);
         }
     }
 

--- a/src/models/itemspage.cpp
+++ b/src/models/itemspage.cpp
@@ -125,6 +125,9 @@ void ItemsPage::insertItem(const QString id, int page, int pos)
 {
     Q_ASSERT(page >= 0 && page < m_pages.size());
 
+    if (m_pages[page].count() < pos)
+        pos = m_pages[page].count();
+
     m_pages[page].insert(pos, id);
     if (m_pages[page].size() > m_maxItemCountPerPage) {
         QString last = m_pages[page].takeLast();


### PR DESCRIPTION
…the shell crashes

Deleted the original app prematurely causing an out-of-bounds error

Issue: https://github.com/linuxdeepin/developer-center/issues/8457