### PR TITLE
fix: cannot turn page by page turning indicator after the right mouse…

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -340,6 +340,17 @@ Control {
                                 folderId: 0
                             }
 
+                            MouseArea {
+                                anchors.fill: parent
+                                acceptedButtons: Qt.RightButton
+                                onClicked: {
+                                    // FIXME: prevent the bug:https://bugreports.qt.io/browse/QTBUG-125139;
+                                    if (mouse.button === Qt.RightButton) {
+                                        mouse.accepted = false;
+                                    }
+                                }
+                            }
+
                             GridViewContainer {
                                 id: gridViewContainer
                                 objectName: "gridViewContainer"


### PR DESCRIPTION
… clicked

cannot turn page by page turning indicator after the right mouse clicked。
adopt evasive method for Qt's bug:https://bugreports.qt.io/browse/QTBUG-125139

Log: fix cannot turn page by page turning indicator after the right mouse clicked
Issue: https://github.com/linuxdeepin/developer-center/issues/8475
Influence: can turn page by page turning indicator after the right mouse