### PR TITLE
chore: rework how showContextMenu() works

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -47,7 +47,7 @@ Loader {
             }
             MenuItem {
                 id: addOrRemoveFavMenu
-                visible: false // !hideFavoriteMenu
+                visible: !hideFavoriteMenu
                 enabled: false
                 height: visible ? implicitHeight : 0 // FIXME: same as above
                 text: FavoritedProxyModel.exists(root.desktopId) ? qsTr("Remove from favorites") : qsTr("Add to favorites")

--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -235,7 +235,7 @@ Popup {
                                                 launchApp(desktopId)
                                             }
                                             onMenuTriggered: {
-                                                showContextMenu(this, model, false, false, true)
+                                                showContextMenu(this, model)
                                             }
                                         }
                                     }

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -444,7 +444,8 @@ Control {
                                             console.log("open folder id:" + idNum)
                                         }
                                         onMenuTriggered: {
-                                            showContextMenu(this, model, folderIcons, false, true)
+                                            if (folderIcons) return;
+                                            showContextMenu(this, model)
                                         }
                                     }
                                 }
@@ -485,7 +486,7 @@ Control {
                         launchApp(desktopId)
                     }
                     onMenuTriggered: {
-                        showContextMenu(this, model, false, false, true)
+                        showContextMenu(this, model)
                     }
                 }
             }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -59,17 +59,15 @@ QtObject {
 
     property var activeMenu: null
     property Component appContextMenuCom: AppItemMenu { }
-    function showContextMenu(obj, model, folderIcons, isFavoriteItem, hideFavoriteMenu) {
-        if (folderIcons) return
-
-        const menu = appContextMenuCom.createObject(obj, {
+    function showContextMenu(obj, model, additionalProps = {}) {
+        const menu = appContextMenuCom.createObject(obj, Object.assign({
             display: model.display,
             desktopId: model.desktopId,
             iconName: model.iconName,
-            isFavoriteItem: isFavoriteItem,
-            hideFavoriteMenu: hideFavoriteMenu,
+            isFavoriteItem: false,
+            hideFavoriteMenu: true,
             hideDisplayScalingMenu: false
-        });
+        }, additionalProps));
         menu.closed.connect(menu.destroy)
         menu.popup();
 

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -202,7 +202,7 @@ FocusScope {
                 TapHandler {
                     acceptedButtons: Qt.RightButton
                     onTapped: {
-                        showContextMenu(itemDelegate, model, false, false, false)
+                        showContextMenu(itemDelegate, model)
                     }
                 }
 

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -180,7 +180,7 @@ Item {
                         if (mouse.button === Qt.RightButton) {
                             // not folder
                             if (iconName)
-                                showContextMenu(itemDelegate, model, false, false, false)
+                                showContextMenu(itemDelegate, model)
                         } else {
                             if (itemType === ItemArrangementProxyModel.FolderItemType) {
                                 console.log("freesort view folder clicked:", desktopId);

--- a/qml/windowed/FrequentlyUsedView.qml
+++ b/qml/windowed/FrequentlyUsedView.qml
@@ -59,7 +59,7 @@ Control {
                     launchApp(desktopId)
                 }
                 onMenuTriggered: {
-                    showContextMenu(this, model, false, false, true)
+                    showContextMenu(this, model)
                 }
             }
 

--- a/qml/windowed/RecentlyInstalledView.qml
+++ b/qml/windowed/RecentlyInstalledView.qml
@@ -59,7 +59,7 @@ Control {
                     launchApp(desktopId)
                 }
                 onMenuTriggered: {
-                    showContextMenu(this, model, false, false, true)
+                    showContextMenu(this, model)
                 }
             }
             activeFocusOnTab: visible && gridViewFocus

--- a/qml/windowed/SearchResultView.qml
+++ b/qml/windowed/SearchResultView.qml
@@ -49,7 +49,7 @@ Control {
                     launchApp(desktopId)
                 }
                 onMenuTriggered: {
-                    showContextMenu(this, model, false, false, true)
+                    showContextMenu(this, model)
                 }
             }
         }


### PR DESCRIPTION
目前的 showContextMenu() 最后三个参数一方面只看参数值完全不知道是干嘛的，另一方面原本涉及到的需求暂时被裁切了。于是此处对此函数的参数进行调整，移除了后三个参数并给定了合适的默认行为，并另外提供了一个参数用来为构造的菜单可选的指定一些可能所需的额外属性。

与 linuxdeepin/developer-center#8472 稍有关系（但此提交不解决对应的 问题）

Log: