### PR TITLE
chore: release dde-launchpad 0.6.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 if(NOT DEFINED VERSION)
-    set(VERSION 0.6.10)
+    set(VERSION 0.6.11)
 endif()
 
 project(dde-launchpad VERSION ${VERSION})

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-launchpad (0.6.11) unstable; urgency=medium
+
+  * Fix search result overflow
+  * Ensure AppItemMenu is modal (linuxdeepin/developer-center#8477)
+  * Fix numpad quick search not working (linuxdeepin/developer-center#8495)
+
+ -- Wang Zichong <wangzichong@deepin.org>  Fri, 10 May 2024 18:35:00 +0800
+
 dde-launchpad (0.6.10) unstable; urgency=medium
 
   * Fix missing blur (linuxdeepin/developer-center#8468)


### PR DESCRIPTION
Changelog:

  * Fix search result overflow
  * Ensure AppItemMenu is modal (linuxdeepin/developer-center#8477)
  * Fix numpad quick search not working (linuxdeepin/developer-center#8495)

Log: