### PR TITLE
fix: dde-control-center can be uninstalled

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -204,7 +204,7 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
     //   2. ensure dde-control-center, deepin-calendar, dde-file-manager ship their AppStream MetaInfo file
     //   3. remove the hard-coded list below
     static const QStringList defaultCompulsoryAppIdList{
-        "dde-control-center.desktop",
+        "org.deepin.dde.control-center.desktop",
         "dde-computer.desktop",
         "dde-trash.desktop",
         "dde-file-manager.desktop",

--- a/src/models/org.deepin.dde.launchpad.appsmodel.json
+++ b/src/models/org.deepin.dde.launchpad.appsmodel.json
@@ -15,7 +15,7 @@
     },
     "compulsoryAppIdList": {
       "value": [
-        "dde-control-center.desktop",
+        "org.deepin.dde.control-center.desktop",
         "dde-computer.desktop",
         "dde-trash.desktop",
         "dde-file-manager.desktop",


### PR DESCRIPTION
dde-control-center's desktop has changed in commit
https://github.com/linuxdeepin/dde-control-center/pull/1624
