### PR TITLE
fix: missing blur for Menu when it's parent is clip

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-launchpad (0.6.12) unstable; urgency=medium
+
+  * fix: dde-control-center can be uninstalled
+  * fix: missing blur for Menu when it's parent is clip(Issue: https://github.com/linuxdeepin/developer-center/issues/8468)
+
+ -- YeShanShan <yeshanshan@deepin.org>  Tue, 14 May 2024 18:26:49 +0800
+
 dde-launchpad (0.6.11) unstable; urgency=medium
 
   * Fix search result overflow

--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -26,7 +26,8 @@ Loader {
 
         Menu {
             id: contextMenu
-            modal: true
+
+            // modal: true //https://github.com/linuxdeepin/developer-center/issues/8571
 
             MenuItem {
                 text: qsTr("Open")

--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -129,13 +129,14 @@ Popup {
 
                     SwipeView {
                         id: folderPagesView
-                        clip: true
+                        clip: gridViews.count > 1
 
                         anchors.fill: parent
 
                         currentIndex: folderPageIndicator.currentIndex
 
                         Repeater {
+                            id: gridViews
                             model: ItemArrangementProxyModel.pageCount(folderLoader.currentFolderId) // FIXME: should be a property?
 
                             Loader {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -60,7 +60,13 @@ QtObject {
     property var activeMenu: null
     property Component appContextMenuCom: AppItemMenu { }
     function showContextMenu(obj, model, additionalProps = {}) {
-        const menu = appContextMenuCom.createObject(obj, Object.assign({
+        if (!obj || !obj.Window.window) {
+            console.log("obj or obj.Window.window is null")
+            return
+        }
+        closeContextMenu()
+
+        const menu = appContextMenuCom.createObject(obj.Window.window.contentItem, Object.assign({
             display: model.display,
             desktopId: model.desktopId,
             iconName: model.iconName,


### PR DESCRIPTION
We use window instead of Item as Menu's parent.

TODO: it's a bug for dtk.

Issue: https://github.com/linuxdeepin/developer-center/issues/8468
