### PR TITLE
chore: now require AppStreamQt 1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-if(NOT DEFINED VERSION)
-    set(VERSION 0.6.11)
-endif()
-
-project(dde-launchpad VERSION ${VERSION})
+project(dde-launchpad VERSION 0.6.12)
 
 option(BUILD_TEST "Whether or not to build the tests" OFF)
 
@@ -30,7 +26,7 @@ set(ASQT_NS AppStreamQt)
 find_package(QT NAMES ${QT_NS} REQUIRED COMPONENTS Core)
 find_package(${QT_NS} REQUIRED COMPONENTS Core Gui Concurrent Qml Svg Quick QuickControls2 LinguistTools)
 find_package(${DTK_NS} REQUIRED COMPONENTS Core Gui)
-find_package(${ASQT_NS} 1.0)
+find_package(${ASQT_NS} 1.0 REQUIRED)
 
 set_package_properties(${ASQT_NS} PROPERTIES
     DESCRIPTION "Library that lists Appstream resources"

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Build-Depends:
  libdtk6gui-dev,
  libdtk6declarative-dev,
  libdde-shell-dev (>= 0.0.10),
- libappstreamqt-dev
+ libappstreamqt-dev (>= 1.0.0)
 Standards-Version: 4.6.0
 Rules-Requires-Root: no
 

--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -13,9 +13,7 @@
 #include <appinfo.h>
 #include <appmgr.h>
 
-#ifndef NO_APPSTREAM_QT
 #include <AppStreamQt/pool.h>
-#endif
 
 #include "appwiz.h"
 #include "ddedock.h"

--- a/src/ddeintegration/CMakeLists.txt
+++ b/src/ddeintegration/CMakeLists.txt
@@ -144,14 +144,4 @@ target_link_libraries(dde-integration-dbus
 PUBLIC
     Qt::Concurrent
 PRIVATE
-    Qt::Core Qt::Gui ${DTK_NS}::Core launcher-utils)
-
-if (${ASQT_NS}_FOUND)
-    target_link_libraries(dde-integration-dbus
-    PRIVATE
-        ${ASQT_NS})
-else()
-    target_compile_definitions(dde-integration-dbus
-    PUBLIC NO_APPSTREAM_QT
-    )
-endif()
+    Qt::Core Qt::Gui ${DTK_NS}::Core ${ASQT_NS} launcher-utils)


### PR DESCRIPTION
之前由于仓库尚不存在 1.x 版本的 AppStream 软件包，所以尽管 debian 依赖写了对 appstreamqt 的依赖，但实际对应的支持是不会被启用的。现 AppStream 1.0.3 已进入 deepin 仓库，故开始强制要求 AppStream 依赖 存在。

与 linuxdeepin/dde-launchpad#281 有一定相关性（原为 AppStream 配置 不存在时提供的后备方案）。
