### PR TITLE
fix: should avoid fcitx and printer get uninstalled

### DIFF
--- a/src/models/org.deepin.dde.launchpad.appsmodel.json
+++ b/src/models/org.deepin.dde.launchpad.appsmodel.json
@@ -15,7 +15,6 @@
     },
     "compulsoryAppIdList": {
       "value": [
-        "org.deepin.dde.control-center.desktop",
         "dde-computer.desktop",
         "dde-trash.desktop",
         "dde-file-manager.desktop",
@@ -23,9 +22,11 @@
         "deepin-manual.desktop",
         "deepin-system-monitor.desktop",
         "deepin-devicemanager.desktop",
-        "dde-printer.desktop",
-        "deepin-app-store.desktop",
-        "dde-calendar.desktop"
+        "dde-printer-watch.desktop",
+        "dde-calendar.desktop",
+        "org.fcitx.fcitx5-migrator.desktop",
+        "fcitx5-configtool.desktop",
+        "org.fcitx.Fcitx5.desktop"
       ],
       "serial": 0,
       "flags": [],


### PR DESCRIPTION
避免 fcitx 与打印机组件从 launcher 中被卸载。

请注意：此列表以当前需求最新版为准，原始 issue 中列出的强制依赖项目
与最新需求并不完全相符，例如计算器与 UOS AI 在最新需求中均为非强制
依赖。

另请注意：应当尽可能避免 launchpad 硬编码不可卸载的应用列表。若应用
本身被视为桌面环境的强制依赖（卸载会导致桌面环境不可用），则应用应当
使用 AppStream 元信息标注自己为不可被卸载。launchpad 会遵循此信息。
可参见控制中心与应用商店当前的做法。

Issue: linuxdeepin/developer-center#8674
Log: