### PR TITLE
feat: add option to move item to top in FreeSortListView

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -17,6 +17,7 @@ Loader {
     property string iconName
     property bool isFavoriteItem
     property bool hideFavoriteMenu
+    property bool hideMoveToTopMenu
     property bool hideDisplayScalingMenu
 
     signal closed()
@@ -31,6 +32,7 @@ Loader {
 
             MenuItem {
                 text: qsTr("Open")
+                enabled: !root.desktopId.startsWith("internal/folders/")
                 onTriggered: {
                     launchApp(root.desktopId)
                 }
@@ -44,6 +46,15 @@ Loader {
                 text: qsTr("Pin to Top")
                 onTriggered: {
                     FavoritedProxyModel.pinToTop(root.desktopId)
+                }
+            }
+            MenuItem {
+                id: moveToTopMenu
+                visible: !hideMoveToTopMenu
+                height: visible ? implicitHeight : 0
+                text: qsTr("Move to Top")
+                onTriggered: {
+                    ItemArrangementProxyModel.bringToFront(root.desktopId)
                 }
             }
             MenuItem {
@@ -65,6 +76,7 @@ Loader {
                 height: visible ? implicitHeight : 0 // FIXME: same as above
             }
             MenuItem {
+                enabled: !root.desktopId.startsWith("internal/folders/")
                 text: DesktopIntegration.isOnDesktop(root.desktopId) ? qsTr("Remove from desktop") : qsTr("Send to desktop")
                 onTriggered: {
                     if (DesktopIntegration.isOnDesktop(root.desktopId)) {
@@ -87,6 +99,7 @@ Loader {
             }
             MenuSeparator {}
             MenuItem {
+                enabled: !root.desktopId.startsWith("internal/folders/")
                 text: DesktopIntegration.isAutoStart(root.desktopId) ? qsTr("Remove from startup") : qsTr("Add to startup")
                 onTriggered: {
                     DesktopIntegration.setAutoStart(root.desktopId, !DesktopIntegration.isAutoStart(root.desktopId))
@@ -100,6 +113,7 @@ Loader {
             }
             MenuItem {
                 visible: !hideDisplayScalingMenu
+                enabled: !root.desktopId.startsWith("internal/folders/")
                 height: visible ? implicitHeight : 0 // FIXME: same as above
                 checkable: true
                 checked: DesktopIntegration.disableScale(root.desktopId)
@@ -109,7 +123,7 @@ Loader {
                 }
             }
             MenuItem {
-                enabled: !DesktopIntegration.appIsCompulsoryForDesktop(root.desktopId)
+                enabled: !root.desktopId.startsWith("internal/folders/") && !DesktopIntegration.appIsCompulsoryForDesktop(root.desktopId)
                 text: qsTr("Uninstall")
                 onTriggered: {
                     LauncherController.visible = false

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -72,7 +72,8 @@ QtObject {
             iconName: model.iconName,
             isFavoriteItem: false,
             hideFavoriteMenu: true,
-            hideDisplayScalingMenu: false
+            hideDisplayScalingMenu: false,
+            hideMoveToTopMenu: true
         }, additionalProps));
         menu.closed.connect(menu.destroy)
         menu.popup();

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -178,9 +178,9 @@ Item {
 
                     onClicked: function (mouse) {
                         if (mouse.button === Qt.RightButton) {
-                            // not folder
-                            if (iconName)
-                                showContextMenu(itemDelegate, model)
+                            showContextMenu(itemDelegate, model, {
+                                hideMoveToTopMenu: index === 0
+                            })
                         } else {
                             if (itemType === ItemArrangementProxyModel.FolderItemType) {
                                 console.log("freesort view folder clicked:", desktopId);

--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -44,6 +44,26 @@ void ItemArrangementProxyModel::updateFolderName(int folderId, const QString &na
     saveItemArrangementToUserData();
 }
 
+void ItemArrangementProxyModel::bringToFront(const QString & id)
+{
+    std::tuple<int, int, int> origPos = findItem(id);
+
+    // can only bring top-level item to front
+    if (std::get<0>(origPos) != 0) return;
+
+    // already at front
+    if (std::get<1>(origPos) == 0 && std::get<2>(origPos) == 0) return;
+
+    m_topLevel->moveItemPosition(std::get<1>(origPos), std::get<2>(origPos), 0, 0, false);
+
+    saveItemArrangementToUserData();
+
+    // Lazy solution, just notify the view that all rows and its roles are changed so they need to be updated.
+    emit dataChanged(index(0, 0), index(rowCount() - 1, 0), {
+        PageRole, IndexInPageRole, FolderIdNumberRole, IconsNameRole
+    });
+}
+
 void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const QString &dropId, const DndOperation op, int pageHint)
 {
     if (dragId == dropId) return;

--- a/src/models/itemarrangementproxymodel.h
+++ b/src/models/itemarrangementproxymodel.h
@@ -56,6 +56,7 @@ public:
 
     Q_INVOKABLE int pageCount(int folderId = 0) const;
     Q_INVOKABLE void updateFolderName(int folderId, const QString & name);
+    Q_INVOKABLE void bringToFront(const QString & id);
     Q_INVOKABLE void commitDndOperation(const QString & dragId, const QString & dropId, const DndOperation op, int pageHint = -1);
     Q_INVOKABLE int creatEmptyPage() const;
     Q_INVOKABLE void removeEmptyPage() const;


### PR DESCRIPTION
添加菜单项，允许移动 item 到最前（仅针对顶层 item 或应用文件夹有效）

此提交也允许对文件夹进行右键点击以供使用对应的菜单项（但当前只有这个
新增项可点击）。另外，本身就处于第一项的 item 不会显示移至顶部菜单。

新增菜单项暂未翻译，文案为暂定文案。

Log: