### PR TITLE
fix: AppListview can not launchApp onKeypressed

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -206,14 +206,6 @@ FocusScope {
                     }
                 }
 
-                Keys.onReturnPressed: {
-                    launchApp(desktopId)
-                }
-
-                Keys.onSpacePressed: {
-                    launchApp(desktopId)
-                }
-
                 TapHandler {
                     onTapped: {
                         launchApp(desktopId)
@@ -225,6 +217,14 @@ FocusScope {
                     implicitHeight: Helper.windowed.listItemHeight
                     button: itemDelegate
                 }
+            }
+
+            Keys.onReturnPressed: {
+                launchApp(desktopId)
+            }
+
+            Keys.onSpacePressed: {
+                launchApp(desktopId)
             }
         }
     }


### PR DESCRIPTION
作用域小了，往外移一个级别即可

Issue: https://github.com/linuxdeepin/developer-center/issues/8584