### PR TITLE
fix: AppItem displayName is incorrect for desktop files which X-Deepin-Vendor is not "deepin"

### DIFF
--- a/src/ddeintegration/appmgr.cpp
+++ b/src/ddeintegration/appmgr.cpp
@@ -76,9 +76,9 @@ static AppMgr::AppItem *parseDBus2AppItem(const ObjectInterfaceMap &source)
         item->categories = value.value();
     }
 
-    // fallback to Name if GenericName is empty for X_Deepin_Vendor.
+    // fallback to Name if GenericName is empty, only for X_Deepin_Vendor equals to "deepin".
     const auto deepinVendor = parseDBusField<QString>(appInfo, u8"X_Deepin_Vendor");
-    item->displayName = getDisplayName(deepinVendor && !deepinVendor.value().isEmpty(),
+    item->displayName = getDisplayName(deepinVendor && deepinVendor.value() == QStringLiteral("deepin"),
                                        parseDBusField<QStringMap>(appInfo, u8"Name").value(),
                                        parseDBusField<QStringMap>(appInfo, u8"GenericName").value());
 


### PR DESCRIPTION
According to Dtk::Core::DDesktopEntry::ddeDisplayName, GenericName should only be used when X-Deepin-Vendor equals to "deepin"
Some desktop entry files X-Deepin-Vendor is set to "user-custom", should use Name as displayName (e.g. deepin-IDE)

Log: In parseDBus2AppItem, use GenericName as displayName only when X-Deepin-Vendor equals to "deepin"