### PR TITLE
fix: Show full app name tooltips for truncated app name in windowed mode

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -198,6 +198,9 @@ FocusScope {
                 anchors.leftMargin: 10
                 anchors.rightMargin: 10
                 // icon.source: "image://app-icon/" + iconName;
+                ToolTip.text: text
+                ToolTip.delay: 1000
+                ToolTip.visible: hovered && contentItem.implicitWidth > contentItem.width
 
                 TapHandler {
                     acceptedButtons: Qt.RightButton

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -142,6 +142,10 @@ Item {
                 palette.windowText: parent.palette.brightText
                 visible: !Drag.active
 
+                ToolTip.text: text
+                ToolTip.delay: 1000
+                ToolTip.visible: hovered && contentItem.implicitWidth > contentItem.width
+
                 Drag.hotSpot.x: width / 3
                 Drag.hotSpot.y: height / 2
                 Drag.dragType: Drag.Automatic


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/8244
Log: Show full app name tooltips for truncated app name in windowed mode