### PR TITLE
fix: crash on dnd the only item in the page

### DIFF
--- a/src/models/itemspage.cpp
+++ b/src/models/itemspage.cpp
@@ -46,7 +46,7 @@ int ItemsPage::pageCount() const
     return m_pages.size();
 }
 
-QStringList ItemsPage::items(int page)
+QStringList ItemsPage::items(int page) const
 {
     return m_pages.at(page);
 }
@@ -249,6 +249,14 @@ int ItemsPage::itemCount() const
         count += pageItems.count();
     }
     return count;
+}
+
+int ItemsPage::itemCount(int page) const
+{
+    if (page >= pageCount())
+        return 0;
+
+    return items(page).count();
 }
 
 // item will be moved to the index

--- a/src/models/itemspage.h
+++ b/src/models/itemspage.h
@@ -26,10 +26,11 @@ public:
     int maxItemCountPerPage() const;
 
     int pageCount() const;
-    QStringList items(int page = 0);
+    QStringList items(int page = 0) const;
     QStringList firstNItems(int count = 4);
     QStringList allArrangedItems() const;
     int itemCount() const;
+    int itemCount(int page) const;
 
     void appendEmptyPage();
     void appendPage(const QStringList items);


### PR DESCRIPTION
- 拖拽唯一的图标到当前页不处理
- 拖拽到唯一的图标到自动新增的页先保留空页在插入最后清理

pages 如果提前清理了，然后去访问新的页码会超出范围

Issue: https://github.com/linuxdeepin/developer-center/issues/8384