### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+dde-launchpad (0.7.1) unstable; urgency=medium
+
+  * Fix #8577
+  * Fix #8862
+  * Fix #8376
+  * Fix #8689
+  * Fix #8244
+  * Fix #8384
+  * release 0.7.1
+
+ -- Mike Chen <chenke@deepin.org>  Wed, 05 Jun 2024 16:37:53 +0800
+
 dde-launchpad (0.7.0) unstable; urgency=medium
 
   * Fix missing border in popup (linuxdeepin/developer-center#8409)


### PR DESCRIPTION
release 0.7.1

Log: bump version to 0.7.1
- linuxdeepin/developer-center#8577
- linuxdeepin/developer-center#8862
- linuxdeepin/developer-center#8376
- linuxdeepin/developer-center#8689
- linuxdeepin/developer-center#8244
- linuxdeepin/developer-center#8893