### PR TITLE
fix: View switch button position drift in window mode

### DIFF
--- a/qml/windowed/SideBar.qml
+++ b/qml/windowed/SideBar.qml
@@ -89,8 +89,7 @@ ColumnLayout {
         contentItem: ColumnLayout {
             spacing: 2
             D.DciIcon {
-                width: 16
-                height: 16
+                sourceSize: Qt.size(16, 16)
                 name: isFreeSort ? categorizedIcon("freeSort") : categorizedIcon(CategorizedSortProxyModel.categoryType)
                 palette: D.DTK.makeIconPalette(title.palette)
                 theme: D.DTK.toColorType(title.palette.window)
@@ -99,8 +98,7 @@ ColumnLayout {
 
             D.DciIcon {
                 name: "arrow"
-                width: 12
-                height: 12
+                sourceSize: Qt.size(12, 12)
                 palette: D.DTK.makeIconPalette(title.palette)
                 theme: D.DTK.toColorType(title.palette.window)
                 Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
Use sourceSize to control the size of DciIcon

Issue: https://github.com/linuxdeepin/developer-center/issues/8805