### PR TITLE
fix: cannot hide the window after switching to windowed mode

### DIFF
--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -137,7 +137,6 @@ void LauncherController::setCurrentFrame(const QString &frame)
 
     m_currentFrame = frame;
     qDebug() << "set current frame:" << m_currentFrame;
-    m_timer->start();
     emit currentFrameChanged();
 }
 
@@ -152,11 +151,6 @@ void LauncherController::hideWithTimer()
         qDebug() << "hide with timer";
         setVisible(false);
     }
-}
-
-bool LauncherController::shouldAvoidHideOrActive()
-{
-    return m_timer->isActive();
 }
 
 QFont LauncherController::adjustFontWeight(const QFont &f, QFont::Weight weight)

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -47,7 +47,6 @@ public:
     void setCurrentFrame(const QString & frame);
 
     Q_INVOKABLE void hideWithTimer();
-    Q_INVOKABLE bool shouldAvoidHideOrActive();
     Q_INVOKABLE QFont adjustFontWeight(const QFont& f, QFont::Weight weight);
 
 signals:

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -237,13 +237,7 @@ QtObject {
 
         onActiveChanged: {
             if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "WindowedFrame")) {
-                // When composting is disabled, switching mode from fullscreen to windowed mode will cause window
-                // activeChanged signal get emitted. We reused the delay timer here to avoid the window get hide
-                // caused by that.
-                // Issue: https://github.com/linuxdeepin/developer-center/issues/6818
-                if (!LauncherController.shouldAvoidHideOrActive()) {
-                    LauncherController.hideWithTimer()
-                }
+                LauncherController.hideWithTimer()
             }
         }
 
@@ -301,13 +295,7 @@ QtObject {
 
         onActiveChanged: {
             if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "FullscreenFrame")) {
-                // When composting is disabled, switching mode from fullscreen to windowed mode will cause window
-                // activeChanged signal get emitted. We reused the delay timer here to avoid the window get hide
-                // caused by that.
-                // Issue: https://github.com/linuxdeepin/developer-center/issues/6818
-                if (!LauncherController.shouldAvoidHideOrActive()) {
-                    LauncherController.hideWithTimer()
-                }
+                LauncherController.hideWithTimer()
             }
         }
 


### PR DESCRIPTION
为了解决 https://github.com/linuxdeepin/developer-center/issues/6818， 设置了忽略切换模式后 1s 内的 activeChanged 事件。
导致切换到窗口模式后， 1s 内点击空白处，窗口无法再关闭

Issues: linuxdeepin/developer-center#8916