### PR TITLE
fix: udpate blur background on visible changed

### DIFF
--- a/src/ddeintegration/appearance.h
+++ b/src/ddeintegration/appearance.h
@@ -6,7 +6,7 @@
 
 #include <QObject>
 #include <QtConcurrent>
-
+class QUrl;
 class __Appearance1;
 class Appearance : public QObject
 {
@@ -31,10 +31,13 @@ signals:
 
 private:
     void updateCurrentWallpaperBlurhash();
+    void updateAllWallpaper();
 
     __Appearance1 * m_dbusAppearanceIface;
 
     QString m_wallpaperBlurhash;
-    QFutureWatcher<QString> m_blurhashWatcher;
+    QList<QFutureWatcher<QString> *> m_blurhashWatchers;
+    QMap<QUrl, QString> m_wallpaperBlurMap; // { file:blurhash }
     qreal m_opacity = -1;
+
 };

--- a/src/ddeintegration/xml/org.deepin.dde.Appearance1.xml
+++ b/src/ddeintegration/xml/org.deepin.dde.Appearance1.xml
@@ -55,5 +55,6 @@
     <property name="FontSize" type="d" access="readwrite"></property>
     <property name="Opacity" type="d" access="readwrite"/>
     <property name="WallpaperSlideShow" type="s" access="readwrite"/>
+    <property name="WallpaperURls" type="s" access="read"/>
     <property name="QtActiveColor" type="s" access="readwrite"/>
 </interface>


### PR DESCRIPTION
fullscreen show to update background image
先获取所有工作区的壁纸一次性全给（模糊）缓存了，然后获取当前工作区的壁纸直接设置。
后面全屏再显示时直接从缓存里面取缓存好的（模糊）壁纸，这样比较快。


Issue: https://github.com/linuxdeepin/developer-center/issues/8828