### PR TITLE
fix: dde-printer can be uninstalled

### DIFF
--- a/src/models/org.deepin.dde.launchpad.appsmodel.json
+++ b/src/models/org.deepin.dde.launchpad.appsmodel.json
@@ -22,7 +22,7 @@
         "deepin-manual.desktop",
         "deepin-system-monitor.desktop",
         "deepin-devicemanager.desktop",
-        "dde-printer-watch.desktop",
+        "dde-printer.desktop",
         "dde-calendar.desktop",
         "org.fcitx.fcitx5-migrator.desktop",
         "fcitx5-configtool.desktop",


### PR DESCRIPTION
Modify the dde-printer's desktop file name to dde-printer.desktop

Issue: https://github.com/linuxdeepin/developer-center/issues/8674