### PR TITLE
fix: item after folder can be operated

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -254,8 +254,10 @@ Popup {
 
                     Item {
                         anchors.fill: parent
-                        TapHandler {
-                            onTapped: {
+                        MouseArea {
+                            anchors.fill: parent
+                            enabled: contentRoot.nameEditing
+                            onClicked: {
                                 folderNameEdit.editingFinished()
                             }
                         }


### PR DESCRIPTION
maybe TapHander's bug

- https://github.com/linuxdeepin/developer-center/issues/9009
- https://github.com/linuxdeepin/developer-center/issues/8832