### PR TITLE
fix: utools icon not found

### DIFF
--- a/src/models/appsmodel.cpp
+++ b/src/models/appsmodel.cpp
@@ -197,6 +197,8 @@ QVariant AppsModel::data(const QModelIndex &index, int role) const
 
 void AppsModel::updateModelData()
 {
+    IconUtils::tryUpdateIconCache();
+
     beginResetModel();
     qDebug() << "reset model.";
 


### PR DESCRIPTION
Qt‘s icon cache still needs to update