### PR TITLE
bump version to 0.7.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-launchpad (0.7.5) unstable; urgency=medium
+
+  * Fix #6818
+  * Fix #8807
+  * Fix #9374
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Thu, 27 Jun 2024 10:55:50 +0800
+
 dde-launchpad (0.7.4) unstable; urgency=medium
 
   * release 0.7.4

--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -137,7 +137,6 @@ void LauncherController::setCurrentFrame(const QString &frame)
 
     m_currentFrame = frame;
     qDebug() << "set current frame:" << m_currentFrame;
-    m_timer->start();
     emit currentFrameChanged();
 }
 
@@ -152,11 +151,6 @@ void LauncherController::hideWithTimer()
         qDebug() << "hide with timer";
         setVisible(false);
     }
-}
-
-bool LauncherController::shouldAvoidHideOrActive()
-{
-    return m_timer->isActive();
 }
 
 QFont LauncherController::adjustFontWeight(const QFont &f, QFont::Weight weight)

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -47,7 +47,6 @@ public:
     void setCurrentFrame(const QString & frame);
 
     Q_INVOKABLE void hideWithTimer();
-    Q_INVOKABLE bool shouldAvoidHideOrActive();
     Q_INVOKABLE QFont adjustFontWeight(const QFont& f, QFont::Weight weight);
 
 signals:

--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -29,7 +29,10 @@ Popup {
     // anchors.centerIn: parent // seems dtkdeclarative's Popup doesn't have anchors.centerIn
 
     width: cs * 4 + 20 /* padding */
-    height: cs * 3 + 130 /* title height*/
+
+    // TODO: 经验证发现：Poppu窗口高度为奇数时，会多显示一个像素的外边框；为偶数时不会显示
+    // 因此，这里需要保证高度是偶数来确保Popup窗口没有外边框
+    height: (cs * 3) % 2 === 0 ? (cs * 3) : (cs * 3 + 1) + 130 /* title height*/
     x: (parent.width - width) / 2
     y: (parent.height - height) / 2
 
@@ -315,6 +318,7 @@ Popup {
     }
     background: FloatingPanel {
         radius: isWindowedMode ? 12 : 36
+        blurMultiplier: 5.0
         backgroundColor: Palette {
             normal: Qt.rgba(1.0, 1.0, 1.0, 0.2)
             normalDark: Qt.rgba(1.0, 1.0, 1.0, 0.2)

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -236,13 +236,7 @@ QtObject {
 
         onActiveChanged: {
             if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "WindowedFrame")) {
-                // When composting is disabled, switching mode from fullscreen to windowed mode will cause window
-                // activeChanged signal get emitted. We reused the delay timer here to avoid the window get hide
-                // caused by that.
-                // Issue: https://github.com/linuxdeepin/developer-center/issues/6818
-                if (!LauncherController.shouldAvoidHideOrActive()) {
-                    LauncherController.hideWithTimer()
-                }
+                LauncherController.hideWithTimer()
             }
         }
 
@@ -300,13 +294,7 @@ QtObject {
 
         onActiveChanged: {
             if (!active && !DebugHelper.avoidHideWindow && (LauncherController.currentFrame === "FullscreenFrame")) {
-                // When composting is disabled, switching mode from fullscreen to windowed mode will cause window
-                // activeChanged signal get emitted. We reused the delay timer here to avoid the window get hide
-                // caused by that.
-                // Issue: https://github.com/linuxdeepin/developer-center/issues/6818
-                if (!LauncherController.shouldAvoidHideOrActive()) {
-                    LauncherController.hideWithTimer()
-                }
+                LauncherController.hideWithTimer()
             }
         }
 

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -156,6 +156,14 @@ FocusScope {
                                         text: menuItem.text
                                         color: parent.palette.windowText
                                     }
+                                    background: Rectangle {
+                                        property Palette hoveredPalette: DStyle.Style.button.background1
+                                        implicitWidth: DStyle.Style.menu.item.width
+                                        implicitHeight: DStyle.Style.menu.item.height
+                                        visible: menuItem.down || menuItem.highlighted
+                                        color: ColorSelector.hoveredPalette
+                                        radius: 1 // TODO can't display background when using dtk's InWindowBlur.
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
[【deepin_V23_Release】【一般】【立即】【预发布测试】【DDE】【UI】全屏启动器应用组的背景模糊效果优化 #9374](https://github.com/linuxdeepin/developer-center/issues/9374)

[【deepin_V23_Release】【一般】【立即】【预发布测试】【DDE】【UI】窗口启动器应用分类的hover效果问题 #8807](https://github.com/linuxdeepin/developer-center/issues/8807)

[【deepin_V23_beta3】【严重】【立即】【预发布测试】【DDE】【launchpad】关闭窗口特效后，最大化切换最小化时，启动器没有最小化窗口显示 #6818](https://github.com/linuxdeepin/developer-center/issues/6818)


