### PR TITLE
chore: release dde-launchpad 0.8.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,78 @@
+dde-launchpad (0.8.0) unstable; urgency=medium
+
+  * Insufficient transparency of the outer border (linuxdeepin/developer-center#8342)
+  * Can't input Chinese when opening the launcher (linuxdeepin/developer-center#8469)
+  * Cherry-pick fixes from 0.7.x maintenance branch
+
+ -- Wang Zichong <wangzichong@deepin.org>  Wed, 17 Jul 2024 14:04:00 +0800
+
+dde-launchpad (0.7.6) unstable; urgency=medium
+
+  * Fix: #8807
+  * Fix: #9067
+  * Fix: #9446
+  * Fix: #8060
+  * Fix: #9450
+  * Fix: #9449
+  * Fix: #9578
+  * Fix: #9567
+  * Fix: #9615
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Fri, 05 Jul 2024 14:47:36 +0800
+
+dde-launchpad (0.7.5) unstable; urgency=medium
+
+  * Fix #6818
+  * Fix #8807
+  * Fix #9374
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Thu, 27 Jun 2024 10:55:50 +0800
+
+dde-launchpad (0.7.4) unstable; urgency=medium
+
+  * release 0.7.4
+
+ -- Mike Chen <chenke@deepin.org>  Mon, 24 Jun 2024 13:57:42 +0800
+
+dde-launchpad (0.7.3) unstable; urgency=medium
+
+  * Fix #8694
+  * Fix #8805
+  * Fix #8980
+  * Fix #8495
+  * Fix #8828
+  * Fix #7949
+  * Fix #8577
+  * Fix #8824
+  * Fix #8674
+  * Fix #8655
+  * Fix #9009
+  * Fix #8832
+  * Fix #8972
+  * Fix #8342
+  * release 0.7.3
+
+ -- Mike Chen <chenke@deepin.org>  Mon, 17 Jun 2024 10:34:07 +0800
+
+dde-launchpad (0.7.2) unstable; urgency=medium
+
+  * release 0.7.2
+
+ -- Mike Chen <chenke@deepin.org>  Thu, 13 Jun 2024 10:26:10 +0800
+
+dde-launchpad (0.7.1) unstable; urgency=medium
+
+  * fix: folder did not remove without item (linuxdeepin/developer-center#8947)
+  * Fix #8577
+  * Fix #8862
+  * Fix #8376
+  * Fix #8689
+  * Fix #8244
+  * Fix #8384
+  * release 0.7.1
+
+ -- zsien <quezhiyong@deepin.org>  Fri, 07 Jun 2024 15:11:35 +0800
+
 dde-launchpad (0.7.0) unstable; urgency=medium
 
   * Fix missing border in popup (linuxdeepin/developer-center#8409)


### PR DESCRIPTION
Chanwqgelog:

  * Insufficient transparency of the outer border (linuxdeepin/developer-center#8342)
  * Can't input Chinese when opening the launcher (linuxdeepin/developer-center#8469)
  * Cherry-pick fixes from 0.7.x maintenance branch

Log: