### PR TITLE
feat: windowed launcher app-folder animation

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -18,6 +18,7 @@ Popup {
     property alias currentFolderId: folderLoader.currentFolderId
     property alias folderName: folderLoader.folderName
     property var folderNameFont: DTK.fontManager.t2
+    required property point centerPosition
     readonly property bool isWindowedMode: LauncherController.currentFrame === "WindowedFrame"
 
     modal: true
@@ -33,10 +34,10 @@ Popup {
     // TODO: 经验证发现：Poppu窗口高度为奇数时，会多显示一个像素的外边框；为偶数时不会显示
     // 因此，这里需要保证高度是偶数来确保Popup窗口没有外边框
     height: (cs * 3) % 2 === 0 ? (cs * 3) : (cs * 3 + 1) + 130 /* title height*/
-    x: isWindowedMode ? (parent.width - width) / 2 : (parent.width - parent.rightPadding + parent.leftPadding - width) / 2
-    y: isWindowedMode ? (parent.height - height) / 2 : (parent.height - parent.bottomPadding + parent.topPadding - height) / 2
+    x: centerPosition.x - (width / 2)
+    y: centerPosition.y - (height / 2)
 
-    onAboutToHide: {
+    onClosed: {
         // reset folder view
         folderLoader.currentFolderId = -1
     }

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -549,6 +549,7 @@ InputEventItem {
         FolderGridViewPopup {
             id: folderGridViewPopup
             cs: searchResultGridViewContainer.cellHeight
+            centerPosition: Qt.point((parent.width - parent.rightPadding + parent.leftPadding) / 2, (parent.height - parent.bottomPadding + parent.topPadding) / 2)
         }
 
         Keys.forwardTo: [searchEdit]

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -168,15 +168,80 @@ InputEventItem {
         }
     }
 
+    MouseArea {
+        id: cursorPosTracker
+        anchors.fill: parent
+        propagateComposedEvents: true
+    }
+
     FolderGridViewPopup {
         id: folderGridViewPopup
         width: 370
         height: 330
         folderNameFont: LauncherController.adjustFontWeight(DTK.fontManager.t6, Font.Bold)
+        centerPosition: Qt.point(curPointX, curPointY)
+
+        property int startPointX: 0
+        property int startPointY: 0
+        readonly property point endPoint: Qt.point(parent.width / 2, parent.height / 2)
+        property int curPointX: 0
+        property int curPointY: 0
 
         onVisibleChanged: function (visible) {
             if (!visible) {
                 appArea.opacity = 1
+            }
+        }
+
+        enter: Transition {
+            ParallelAnimation {
+                NumberAnimation {
+                    duration: 200
+                    properties: "scale"
+                    easing.type: Easing.OutQuad
+                    from: 0
+                    to: 1
+                }
+                NumberAnimation {
+                    duration: 200
+                    properties: "curPointX"
+                    easing.type: Easing.OutQuad
+                    from: folderGridViewPopup.startPointX
+                    to: folderGridViewPopup.endPoint.x
+                }
+                NumberAnimation {
+                    duration: 200
+                    properties: "curPointY"
+                    easing.type: Easing.OutQuad
+                    from: folderGridViewPopup.startPointY
+                    to: folderGridViewPopup.endPoint.y
+                }
+            }
+        }
+
+        exit: Transition {
+            ParallelAnimation {
+                NumberAnimation {
+                    duration: 200
+                    properties: "scale"
+                    easing.type: Easing.InQuad
+                    from: 1
+                    to: 0
+                }
+                NumberAnimation {
+                    duration: 200
+                    properties: "curPointX"
+                    easing.type: Easing.InQuad
+                    to: folderGridViewPopup.startPointX
+                    from: folderGridViewPopup.endPoint.x
+                }
+                NumberAnimation {
+                    duration: 200
+                    properties: "curPointY"
+                    easing.type: Easing.InQuad
+                    to: folderGridViewPopup.startPointY
+                    from: folderGridViewPopup.endPoint.y
+                }
             }
         }
     }
@@ -238,6 +303,8 @@ InputEventItem {
     Connections {
         target: appList
         function onFreeSortViewFolderClicked(folderId, folderName) {
+            folderGridViewPopup.startPointX = cursorPosTracker.mouseX
+            folderGridViewPopup.startPointY = cursorPosTracker.mouseY
             folderGridViewPopup.currentFolderId = folderId
             folderGridViewPopup.folderName = folderName
             folderGridViewPopup.open()


### PR DESCRIPTION
小窗口启动器动画支持

Log:

------

主要注意点：

FolderGridViewPopup 的 popup 背景是个 `FloatingPanel`，提供了模糊功能。此模糊功能在当前状态下动画过程中以及结束后似乎无法得到和无动画时完全一致的渲染效果，推测可能是 dtk bug？ @18202781743 

简单的效果对比方式：

修改 `FolderGridViewPopup.qml` 第 333 行代码为 `blurMultiplier: root.enter.running ? 5.0 : 5.01`，通过更新 blurMultiplier 来触发一次 `FloatingPanel` 重绘，效果就正常了。