### PR TITLE
fix: Frequently used app items will overlap search bar splitline

### DIFF
--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -18,6 +18,6 @@ QtObject {
         property int leftMargin: 10
         property int rightMargin: 10
         property int cellPaddingColumns: 14
-        property int cellPaddingRows: 10
+        property int cellPaddingRows: 6
     }
 }


### PR DESCRIPTION
Reduce appitems row padding

Issue: https://github.com/linuxdeepin/developer-center/issues/9748 
Log: