### PR TITLE
chore: hide app-folder icon when its folder is visible

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -387,6 +387,7 @@ InputEventItem {
                                     delegate: DropArea {
                                         Keys.forwardTo: [iconItemDelegate]
 
+                                        visible: !folderGridViewPopup.visible || folderGridViewPopup.currentFolderId !== Number(model.desktopId.replace("internal/folders/", ""))
                                         width: gridViewContainer.cellWidth
                                         height: gridViewContainer.cellHeight
                                         onEntered: {


### PR DESCRIPTION
当应用文件夹显示时，隐藏应用文件夹图标本身。

Log: