### PR TITLE
fix: Cannot open apps inside folders with keyboard

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -262,8 +262,10 @@ Popup {
 
                                             dropOnItem(dragId, model.desktopId, op)
                                         }
+                                        Keys.forwardTo: [innerItem]
 
                                         IconItemDelegate {
+                                            id: innerItem
                                             anchors.fill: parent
                                             dndEnabled: true
                                             displayFont: isWindowedMode ? DTK.fontManager.t9 : DTK.fontManager.t6


### PR DESCRIPTION
Key events are filtered by upper droparea delegate, and need to be forwarded to inner IconItemDelegate.

Issue: https://github.com/linuxdeepin/developer-center/issues/9930
Log: Cannot open apps inside folders with keyboard