### PR TITLE
fix: fullscreen frame follows the dock

### DIFF
--- a/dde-shell-wrapper/package/main.qml
+++ b/dde-shell-wrapper/package/main.qml
@@ -8,7 +8,9 @@ import org.deepin.launchpad 1.0
 ContainmentItem {
     id: root
     property point windowedPos: Qt.point(0, 0)
+    property alias fullscreenFrame: main.fullscreenFrame
     Main {
+        id: main
         windowedPos: root.windowedPos
     }
 


### PR DESCRIPTION
Set the screen of the dock to the screen of the fullscreen frame

Issue: https://github.com/linuxdeepin/developer-center/issues/7188