### PR TITLE
fix!: correct app id used by DConfig

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,7 +29,7 @@ Copyright: None
 License: CC0-1.0
 
 # dconfig base template files
-Files: */org.deepin.dde.launchpad.*.json
+Files: */org.deepin.dde.*.json
 Copyright: None
 License: CC0-1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${TRANSLATED_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/${BIN_NAME}/translations)
 install(
-    FILES dist/org.deepin.dde.launchpad.appdata.xml
+    FILES dist/org.deepin.dde.shell.launchpad.appdata.xml
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo"
 )
 

--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -200,12 +200,11 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
     , m_dockIntegration(new DdeDock(this))
     , m_appearanceIntegration(new Appearance(this))
 {
-    QScopedPointer<DConfig> dconfig(DConfig::create("dde-launchpad", "org.deepin.dde.launchpad.appsmodel"));
+    QScopedPointer<DConfig> dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
     Q_ASSERT_X(dconfig->isValid(), "DConfig", "DConfig file is missing or invalid");
     // TODO:
-    //   1. ensure dde-launchpad is build with AppStream support
-    //   2. ensure dde-control-center, deepin-calendar, dde-file-manager ship their AppStream MetaInfo file
-    //   3. remove the hard-coded list below
+    //   1. ensure dde-control-center, deepin-calendar, dde-file-manager ship their AppStream MetaInfo file
+    //   2. remove the hard-coded list below
     static const QStringList defaultCompulsoryAppIdList{
         "org.deepin.dde.control-center.desktop",
         "dde-computer.desktop",

--- a/dist/org.deepin.dde.shell.launchpad.appdata.xml
+++ b/dist/org.deepin.dde.shell.launchpad.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component>
-  <id>org.deepin.dde.launchpad</id>
+  <id>org.deepin.dde.shell.launchpad</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>DDE Launchpad</name>

--- a/docs/DConfig.md
+++ b/docs/DConfig.md
@@ -20,16 +20,16 @@ Some heads-up:
 - `dde-dconfig-editor` is a GUI util to tweak those values.
   - `readonly` fields will be read-only in the editor, but it's override-able!
 - `dde-dconfig` cli util can be used to test out the config values when needed:
-  - Example usage: `dde-dconfig get -a dde-launchpad -r org.deepin.dde.launchpad.appsmodel -k excludeAppIdList`
+  - Example usage: `dde-dconfig get -a org.deepin.dde.shell -r org.deepin.ds.launchpad -k excludeAppIdList`
 - If you just changed the on-disk base configuration template file or override file, dde-dconfig service might still holding a outdated cache!
   - To avoid that, simply restart the service: `systemctl restart dde-dconfig-daemon.service`.
-  - `dde-config`'s `reset` option won't clear the default value cache that offered by base configuration template file and override file. i.e. things like `dde-dconfig reset -a dde-launchpad -r org.deepin.dde.launchpad.appsmodel -k excludeAppIdList` won't work as intended.
+  - `dde-config`'s `reset` option won't clear the default value cache that offered by base configuration template file and override file. i.e. things like `dde-dconfig reset -a org.deepin.dde.shell -r org.deepin.ds.launchpad -k excludeAppIdList` won't work as intended.
 
 ### OEM Configuration Quick Guide
 
 The base configuration template is **usually** located at `/usr/share/dsg/configs/${app-id}/${conf-desc-file}.json`. Redistributors can override this configuration template by putting files under `/usr/share/dsg/configs/overrides/${app-id}/${conf-desc-file}/${preferred-oem-filename}.json`. Please note the json structure of the base template file and the override file are different. Please consult the related documentations for detail information.
 
-- `${app-id}`: the name of the executable, `dde-launchpad` in this case.
+- `${app-id}`: the name of the executable, `org.deepin.dde.shell` in this case.
 - `${conf-desc-file}`: the name of the base configuration template file, without the `.json` suffix.
 - `${preferred-oem-filename}`: can be any name, please notice only latin characters are allowed.
 
@@ -37,7 +37,7 @@ The base configuration template is **usually** located at `/usr/share/dsg/config
 
 ## Configurations
 
-### org.deepin.dde.launchpad.appsmodel
+### org.deepin.ds.launchpad
 
 #### `excludeAppIdList` (readonly)
 

--- a/src/models/CMakeLists.txt
+++ b/src/models/CMakeLists.txt
@@ -56,7 +56,14 @@ target_link_libraries(launcher-models PRIVATE
     launcher-utils
 )
 
+# legacy one, provided for migration purpose (begin)
 dtk_add_config_meta_files(
-  APPID ${PROJECT_NAME}
-  FILES org.deepin.dde.launchpad.appsmodel.json
+    APPID ${PROJECT_NAME}
+    FILES org.deepin.dde.launchpad.appsmodel.json
+)
+# (end)
+
+dtk_add_config_meta_files(
+    APPID org.deepin.dde.shell
+    FILES org.deepin.ds.launchpad.json
 )

--- a/src/models/appsmodel.cpp
+++ b/src/models/appsmodel.cpp
@@ -38,7 +38,7 @@ static void updateAppItemFromAM(AppItem *appItem)
 
 AppsModel::AppsModel(QObject *parent)
     : QStandardItemModel(parent)
-    , m_dconfig(DConfig::create("dde-launchpad", "org.deepin.dde.launchpad.appsmodel"))
+    , m_dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"))
     , m_tmUpdateCache(new QTimer(this))
 {
     Q_ASSERT_X(m_dconfig->isValid(), "DConfig", "DConfig file is missing or invalid");

--- a/src/models/categorizedsortproxymodel.cpp
+++ b/src/models/categorizedsortproxymodel.cpp
@@ -29,7 +29,7 @@ void CategorizedSortProxyModel::setCategoryType(CategoryType categoryType)
     }
 
     if (oldCategoryType != categoryType) {
-        QScopedPointer<DConfig> config(DConfig::create("dde-launchpad", "org.deepin.dde.launchpad.appsmodel"));
+        QScopedPointer<DConfig> config(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
         config->setValue("categoryType", categoryType);
         emit categoryTypeChanged();
     }
@@ -131,7 +131,7 @@ CategorizedSortProxyModel::CategorizedSortProxyModel(QObject *parent)
 {
     setSortCaseSensitivity(Qt::CaseInsensitive);
     setSourceModel(&AppsModel::instance());
-    QScopedPointer<DConfig> config(DConfig::create("dde-launchpad", "org.deepin.dde.launchpad.appsmodel"));
+    QScopedPointer<DConfig> config(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
     CategoryType categoryType = CategoryType(config->value("categoryType", FreeCategory).toInt());
     isFreeSort = (categoryType == FreeCategory);
     setCategoryType(categoryType);

--- a/src/models/frequentlyusedproxymodel.cpp
+++ b/src/models/frequentlyusedproxymodel.cpp
@@ -12,7 +12,7 @@ DCORE_USE_NAMESPACE
 FrequentlyUsedProxyModel::FrequentlyUsedProxyModel(QObject *parent)
     : QSortFilterProxyModel(parent)
 {
-    QScopedPointer<DConfig> dconfig(DConfig::create("dde-launchpad", "org.deepin.dde.launchpad.appsmodel"));
+    QScopedPointer<DConfig> dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
     // lower priority is higher.
     m_frequentlyUsedAppIdList = dconfig->value("frequentlyUsedAppIdList").toStringList();
     qDebug() << "Fetched frequentlyUsed app list by DConfig" << m_frequentlyUsedAppIdList;

--- a/src/models/org.deepin.ds.launchpad.json
+++ b/src/models/org.deepin.ds.launchpad.json
@@ -1,0 +1,80 @@
+{
+  "magic": "dsg.config.meta",
+  "version": "1.0",
+  "contents": {
+    "excludeAppIdList": {
+      "value": [],
+      "serial": 0,
+      "flags": [],
+      "name": "Exclude Application ID List",
+      "name[zh_CN]": "应用排除 ID 列表",
+      "description": "List of application's desktop IDs that should be exclude/hidden from the launchpad.",
+      "description[zh_CN]": "需要使 launchpad 排除（避免显示）的应用程序的 desktop ID 列表。",
+      "permissions": "readonly",
+      "visibility": "private"
+    },
+    "compulsoryAppIdList": {
+      "value": [
+        "dde-computer.desktop",
+        "dde-trash.desktop",
+        "dde-file-manager.desktop",
+        "deepin-terminal.desktop",
+        "deepin-manual.desktop",
+        "deepin-system-monitor.desktop",
+        "deepin-devicemanager.desktop",
+        "dde-printer.desktop",
+        "dde-calendar.desktop",
+        "org.fcitx.fcitx5-migrator.desktop",
+        "fcitx5-configtool.desktop",
+        "org.fcitx.Fcitx5.desktop"
+      ],
+      "serial": 0,
+      "flags": [],
+      "name": "Compulsory Application ID List",
+      "name[zh_CN]": "核心必要应用 ID 列表",
+      "description": "The desktop ID list for applications considered as compulsory.",
+      "description[zh_CN]": "需要被视为核心必要应用的应用 ID 列表。",
+      "permissions": "readonly",
+      "visibility": "private"
+    },
+    "frequentlyUsedAppIdList": {
+      "value": [
+          "org.deepin.browser.desktop",
+          "deepin-app-store.desktop",
+          "dde-file-manager.desktop",
+          "deepin-mail.desktop",
+          "deepin-home.desktop",
+          "deepin-screen-recorder.desktop",
+          "deepin-calculator.desktop",
+          "deepin-terminal.desktop",
+          "dde-calendar.desktop",
+          "deepin-image-viewer.desktop",
+          "deepin-movie.desktop",
+          "deepin-album.desktop",
+          "deepin-system-monitor.desktop",
+          "libreoffice-base.desktop",
+          "libreoffice-writer.desktop",
+          "libreoffice-calc.desktop"
+      ],
+      "serial": 0,
+      "flags": [],
+      "name": "Frequently Used Application ID List",
+      "name[zh_CN]": "常用应用 ID 列表",
+      "description": "The default desktop ID list for \"my frequently used\" applications.",
+      "description[zh_CN]": "我的常用中默认显示的应用程序的 desktop ID 列表。",
+      "permissions": "readonly",
+      "visibility": "private"
+    },
+    "categoryType": {
+      "value": 2,
+      "serial": 0,
+      "flags": [],
+      "name": "Application Sort Type",
+      "name[zh_CN]": "应用排序类别",
+      "description": "The type of sorting Application list under windows mode. 0: Alphabetary, 1: DDE Category, 2: Freeform Sort",
+      "description[zh_CN]": "在窗口模式下排序应用列表的类别。0: 首字母分组排序，1: DDE 风格分类，2: 自由排序",
+      "permissions": "readwrite",
+      "visibility": "private"
+    }
+  }
+}


### PR DESCRIPTION
纠正应用组件 ID 名称。

Log:
Influnce: 不再兼容之前的 dde-launchpad 配置文件

---------------------

关联：

- https://github.com/linuxdeepin/dde-launchpad/pull/383 （本 PR）
- https://github.com/linuxdeepin/dde-shell/pull/658
- https://github.com/linuxdeepin/dde-tray-loader/pull/120
- https://github.com/linuxdeepin/deepin-osconfig/pull/7 （可以先合入，不影响测试）

若未注明，均需先确认无问题再合入。