### PR TITLE
feat: set fullscreen window ignore exclusive areas

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -292,6 +292,7 @@ QtObject {
         DLayerShellWindow.anchors: DLayerShellWindow.AnchorBottom | DLayerShellWindow.AnchorTop | DLayerShellWindow.AnchorLeft | DLayerShellWindow.AnchorRight
         DLayerShellWindow.layer: DLayerShellWindow.LayerTop
         DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityOnDemand
+        DLayerShellWindow.exclusionZone: -1
         DLayerShellWindow.scope: "dde-shell/launchpad"
 
         // visibility: Window.FullScreen


### PR DESCRIPTION
Launchpad should be displayed in full screen under wayland

Log: