### PR TITLE
fix: Correct application group popup height

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -33,7 +33,7 @@ Popup {
 
     // TODO: 经验证发现：Poppu窗口高度为奇数时，会多显示一个像素的外边框；为偶数时不会显示
     // 因此，这里需要保证高度是偶数来确保Popup窗口没有外边框
-    height: (cs * 3) % 2 === 0 ? (cs * 3) : (cs * 3 + 1) + 130 /* title height*/
+    height: ((cs * 3) % 2 === 0 ? (cs * 3) : (cs * 3 + 1)) + 130 /* title height*/
     x: centerPosition.x - (width / 2)
     y: centerPosition.y - (height / 2)
 


### PR DESCRIPTION
The height calculation is incorrect for '?:' operator having a lower priority than '+', which results in no title height added when cs is an even number.

Issue:
https://github.com/linuxdeepin/developer-center/issues/10021 https://github.com/linuxdeepin/developer-center/issues/10027 https://github.com/linuxdeepin/developer-center/issues/10320 Log: Correct application group popup height