### PR TITLE
fix: gridView tab switched too quickly

### DIFF
--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -85,7 +85,7 @@ FocusScope {
                 clip: true
                 highlightFollowsCurrentItem: true
                 keyNavigationEnabled: true
-                highlightMoveDuration: 150
+                highlightMoveDuration: 100
                 activeFocusOnTab: focus ? root.activeGridViewFocusOnTab : false
                 focus: count > 0
                 onActiveFocusChanged: {
@@ -128,6 +128,24 @@ FocusScope {
                 // not wroking
                 move: root.itemMove
                 moveDisplaced: root.itemMove
+
+                Keys.onPressed: function (event) {
+                    if (event.key === Qt.Key_Left ||
+                        event.key === Qt.Key_Right ||
+                        event.key === Qt.Key_Up ||
+                        event.key === Qt.Key_Down) {
+
+                        if (!keyTimer.running) {
+                            keyTimer.start()
+                        } else {
+                            event.accepted = true
+                        }
+                    }
+                }
+                Timer {
+                    id: keyTimer
+                    interval: 100
+                }
             }
         }
 

--- a/qml/windowed/GridViewContainer.qml
+++ b/qml/windowed/GridViewContainer.qml
@@ -66,6 +66,7 @@ FocusScope {
 
             interactive: false
             highlightFollowsCurrentItem: true
+            highlightMoveDuration: 100
             keyNavigationEnabled: true
             activeFocusOnTab: focus ? root.activeGridViewFocusOnTab : false
             focus: count > 0
@@ -96,13 +97,21 @@ FocusScope {
             }
 
             Keys.onPressed: function (event) {
-                if (event.key === Qt.Key_Right && currentIndex === gridView.count - 1) {
-                    gridView.currentIndex = 0;
-                    event.accepted = true;
-                } else if (event.key === Qt.Key_Left && currentIndex === 0) {
-                    currentIndex = gridView.count - 1;
-                    event.accepted = true;
+                if (event.key === Qt.Key_Left ||
+                    event.key === Qt.Key_Right ||
+                    event.key === Qt.Key_Up ||
+                    event.key === Qt.Key_Down) {
+
+                    if (!keyTimer.running) {
+                        keyTimer.start()
+                    } else {
+                        event.accepted = true
+                    }
                 }
+            }
+            Timer {
+                id: keyTimer
+                interval: 100
             }
         }
     }


### PR DESCRIPTION
Limit the interval between repeated clicks

Issue: https://github.com/linuxdeepin/developer-center/issues/10481