### PR TITLE
fix: failed to switch pages by clicking indicator button

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -245,7 +245,7 @@ InputEventItem {
                                 if (isLastPage && !dropArea.createdEmptyPage) {
                                     let newPageIndex = ItemArrangementProxyModel.creatEmptyPage()
                                     dropArea.createdEmptyPage = true
-                                    listviewPage.currentIndex = newPageIndex
+                                    setCurrentIndex(newPageIndex)
                                     parent.pageIntent = 0
                                     return
                                 } else {
@@ -294,6 +294,10 @@ InputEventItem {
                     visible: searchEdit.text === ""
 
                     currentIndex: indicator.currentIndex
+                    function setCurrentIndex(index) {
+                        listviewPage.currentIndex = index
+                        listviewPage.currentIndex = Qt.binding(function() { return indicator.currentIndex })
+                    }
 
                     property int previousIndex: -1
                     model: itemPageModel
@@ -362,7 +366,7 @@ InputEventItem {
                             Keys.onLeftPressed: function(event) {
                                 if (listItem.viewIndex === 0 && itemPageModel.rowCount() > 1) {
                                     // is the 1st page, go to last page
-                                    listviewPage.currentIndex = itemPageModel.rowCount() - 1
+                                    setCurrentIndex(itemPageModel.rowCount() - 1)
                                 } else {
                                     // not the 1st page, simply use SwipeView default behavior
                                     event.accepted = false
@@ -371,7 +375,7 @@ InputEventItem {
                             Keys.onRightPressed: function(event) {
                                 if (listItem.viewIndex === (itemPageModel.rowCount() - 1) && itemPageModel.rowCount() > 1) {
                                     // is the last page, go to last page
-                                    listviewPage.currentIndex = 0
+                                    setCurrentIndex(0)
                                 } else {
                                     // not the last page, simply use SwipeView default behavior
                                     event.accepted = false
@@ -498,7 +502,7 @@ InputEventItem {
                     }
 
                     Component.onCompleted: {
-                        listviewPage.currentIndex = 0
+                        setCurrentIndex(0)
                     }
                 }
 
@@ -681,7 +685,7 @@ InputEventItem {
                 // reset(remove) keyboard focus
                 baseLayer.focus = true
                 // reset page to the first page
-                listviewPage.currentIndex = 0
+                setCurrentIndex(0)
             }
         }
     }


### PR DESCRIPTION
if the property is later assigned a static value from a JavaScript statement, the binding will be removed. 
If you need to assign, please rebind the property after assigning.

Issue: https://pms.uniontech.com/bug-view-272715.html