### PR TITLE
refactor: move launcherItem here and port to dde-shell

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -34,7 +34,7 @@ Copyright: None
 License: CC0-1.0
 
 # translations
-Files: translations/*.ts
+Files: translations/*.ts shell-launcher-applet/translations/*.ts
 Copyright: UnionTech Software Technology Co., Ltd.
 License: GPL-3.0-or-later
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,6 @@ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
 set(QML_IMPORT_PATH ${QML_IMPORT_PATH} ${CMAKE_CURRENT_BINARY_DIR}/ CACHE STRING "" FORCE)
 
-add_subdirectory(systemd)
-add_subdirectory(dbus)
 add_subdirectory(src/gioutils)
 add_subdirectory(src/utils)
 add_subdirectory(src/quick)
@@ -117,15 +115,18 @@ set(TRANSLATION_FILES
 
 qt_add_dbus_adaptor(DBUS_ADAPTER_FILES dbus/org.deepin.dde.Launcher1.xml launchercontroller.h LauncherController)
 
-qt_add_executable(${BIN_NAME}
-    main.cpp
+qt_add_library(liblaunchpad SHARED
     ${SOURCE_FILES}
     ${DBUS_ADAPTER_FILES}
     ${RESOURCES}
     ${TRANSLATED_FILES}
 )
 
-qt_add_qml_module(${BIN_NAME}
+qt_add_executable(${BIN_NAME}
+    main.cpp
+)
+
+qt_add_qml_module(liblaunchpad
     URI org.deepin.launchpad
     VERSION 1.0
     RESOURCES qml.qrc
@@ -146,7 +147,7 @@ PRIVATE
     DDE_LAUNCHPAD_VERSION=${CMAKE_PROJECT_VERSION}
 )
 
-target_link_libraries(${BIN_NAME} PRIVATE
+target_link_libraries(liblaunchpad PUBLIC
     ${DTK_NS}::Core
     ${DTK_NS}::Gui
     Qt::Qml
@@ -162,11 +163,14 @@ target_link_libraries(${BIN_NAME} PRIVATE
     treeland-integration
 )
 
-install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+target_link_libraries(${BIN_NAME} PRIVATE
+    liblaunchpad
+)
+
 install(FILES ${TRANSLATED_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/${BIN_NAME}/translations)
 install(
     FILES dist/org.deepin.dde.shell.launchpad.appdata.xml
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo"
 )
 
-include(dde-shell-wrapper/src.cmake)
+add_subdirectory(shell-launcher-applet)

--- a/shell-launcher-applet/CMakeLists.txt
+++ b/shell-launcher-applet/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+find_package(DDEShell REQUIRED)
+
+add_library(shell-launcherapplet SHARED
+    launcheritem.cpp
+    launcheritem.h
+)
+
+target_link_libraries(shell-launcherapplet PRIVATE
+    Dde::Shell
+    liblaunchpad
+)
+
+ds_install_package(PACKAGE org.deepin.ds.dock.launcherapplet TARGET shell-launcherapplet)
+ds_handle_package_translation(PACKAGE org.deepin.ds.dock.launcherapplet)

--- a/shell-launcher-applet/launcheritem.cpp
+++ b/shell-launcher-applet/launcheritem.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "launcheritem.h"
+#include "pluginfactory.h"
+#include "../launchercontroller.h"
+
+#include <DDBusSender>
+
+#include <applet.h>
+
+namespace dock {
+
+LauncherItem::LauncherItem(QObject *parent)
+    : DApplet(parent)
+    , m_iconName("deepin-launcher")
+{
+
+}
+
+bool LauncherItem::init()
+{
+    DApplet::init();
+
+    QDBusConnection connection = QDBusConnection::sessionBus();
+    if (!connection.registerService(QStringLiteral("org.deepin.dde.Launcher1")) ||
+        !connection.registerObject(QStringLiteral("/org/deepin/dde/Launcher1"), &LauncherController::instance())) {
+        qWarning() << "register dbus service failed";
+    }
+
+    return true;
+}
+
+D_APPLET_CLASS(LauncherItem)
+}
+
+
+#include "launcheritem.moc"

--- a/shell-launcher-applet/launcheritem.h
+++ b/shell-launcher-applet/launcheritem.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "applet.h"
+#include "dsglobal.h"
+
+namespace dock {
+
+class LauncherItem : public DS_NAMESPACE::DApplet
+{
+    Q_OBJECT
+    Q_PROPERTY(QString iconName MEMBER m_iconName NOTIFY iconNameChanged FINAL)
+public:
+    explicit LauncherItem(QObject *parent = nullptr);
+    virtual bool init() override;
+
+Q_SIGNALS:
+    void iconNameChanged();
+
+private:
+    QString m_iconName;
+};
+
+}

--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import org.deepin.dtk 1.0
+
+import org.deepin.ds 1.0
+import org.deepin.dtk 1.0 as D
+import org.deepin.ds.dock 1.0
+
+import org.deepin.launchpad 1.0
+import org.deepin.launchpad.models 1.0
+import org.deepin.launchpad.windowed 1.0
+
+AppletItem {
+    id: launcher
+    property bool useColumnLayout: Panel.position % 2
+    property int dockOrder: 12
+    // 1:4 the distance between app : dock height; get width/height≈0.8
+    implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
+    implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize
+
+    Connections {
+        target: Panel.rootObject
+        function onDockCenterPartPosChanged()
+        {
+            updateLaunchpadPos()
+        }
+    }
+
+    property point itemPos: Qt.point(0, 0)
+    function updateItemPos()
+    {
+        var lX = icon.mapToItem(null, 0, 0).x
+        var lY = icon.mapToItem(null, 0, 0).y
+        launcher.itemPos = Qt.point(lX, lY)
+    }
+    function updateLaunchpadPos()
+    {
+        updateItemPos()
+        var launchpad = DS.applet("org.deepin.ds.launchpad")
+        if (!launchpad || !launchpad.rootObject)
+            return
+
+        launchpad.rootObject.windowedPos = launcher.itemPos
+    }
+    Component.onCompleted: {
+        updateLaunchpadPos()
+    }
+
+    property var activeMenu: null
+    property Component appContextMenuCom: AppItemMenu { }
+    function showContextMenu(obj, model, additionalProps = {}) {
+        if (!obj || !obj.Window.window) {
+            console.log("obj or obj.Window.window is null")
+            return
+        }
+        closeContextMenu()
+
+        const menu = appContextMenuCom.createObject(obj.Window.window.contentItem, Object.assign({
+            display: model.display,
+            desktopId: model.desktopId,
+            iconName: model.iconName,
+            isFavoriteItem: false,
+            hideFavoriteMenu: true,
+            hideDisplayScalingMenu: false,
+            hideMoveToTopMenu: true
+        }, additionalProps));
+        menu.closed.connect(menu.destroy)
+        menu.popup();
+
+        activeMenu = menu
+    }
+
+    function closeContextMenu() {
+        if (activeMenu) {
+            activeMenu.close()
+            activeMenu = null
+        }
+    }
+
+    function getCategoryName(section) {
+        switch (Number(section)) {
+        case AppItem.Internet:
+            return qsTr("Internet");
+        case AppItem.Chat:
+            return qsTr("Chat");
+        case AppItem.Music:
+            return qsTr("Music");
+        case AppItem.Video:
+            return qsTr("Video");
+        case AppItem.Graphics:
+            return qsTr("Graphics");
+        case AppItem.Game:
+            return qsTr("Game");
+        case AppItem.Office:
+            return qsTr("Office");
+        case AppItem.Reading:
+            return qsTr("Reading");
+        case AppItem.Development:
+            return qsTr("Development");
+        case AppItem.System:
+            return qsTr("System");
+        default:
+            return qsTr("Others");
+        }
+    }
+
+    function launchApp(desktopId) {
+        DesktopIntegration.launchByDesktopId(desktopId);
+    }
+
+    PanelToolTip {
+        id: toolTip
+        text: qsTr("launchpad")
+        toolTipX: DockPanelPositioner.x
+        toolTipY: DockPanelPositioner.y
+    }
+
+    property var fullscreenFrame: ApplicationWindow {
+        objectName: "FullscreenFrameApplicationWindow"
+        title: "Fullscreen Launchpad"
+        visible: LauncherController.visible && (LauncherController.currentFrame !== "WindowedFrame")
+        // Set transparent on kwin will cause abnormal rounded corners in FolderPopup, Bug: 10219
+        color: DesktopIntegration.isTreeLand() ? "transparent" : undefined
+        transientParent: null
+
+        DLayerShellWindow.anchors: DLayerShellWindow.AnchorBottom | DLayerShellWindow.AnchorTop | DLayerShellWindow.AnchorLeft | DLayerShellWindow.AnchorRight
+        DLayerShellWindow.layer: DLayerShellWindow.LayerTop
+        DLayerShellWindow.keyboardInteractivity: DLayerShellWindow.KeyboardInteractivityOnDemand
+        DLayerShellWindow.exclusionZone: -1
+        DLayerShellWindow.scope: "dde-shell/launchpad"
+
+        // visibility: Window.FullScreen
+        flags: {
+            if (DebugHelper.useRegularWindow) return Qt.Window
+            return (Qt.FramelessWindowHint | Qt.Tool)
+        }
+
+        DWindow.enabled: !DebugHelper.useRegularWindow
+        DWindow.windowRadius: 0
+        DWindow.enableSystemResize: false
+        DWindow.enableSystemMove: false
+        // Fullscreen mode: always assume dark theme
+        DWindow.themeType: ApplicationHelper.DarkType
+        DWindow.windowStartUpEffect: PlatformHandle.EffectOut
+
+        onVisibleChanged: {
+            if (visible) {
+                requestActivate()
+            }
+        }
+
+        onActiveChanged: {
+            if (LauncherController.currentFrame !== "FullscreenFrame") {
+                return
+            }
+            if (active) {
+                LauncherController.cancelHide()
+                return;
+            }
+            if (!active && !DebugHelper.avoidHideWindow) {
+                LauncherController.hideWithTimer()
+            }
+        }
+
+        Loader {
+            anchors.fill: parent
+            focus: true
+            sourceComponent: FullscreenFrame {}
+
+            Label {
+                visible: DebugHelper.qtDebugEnabled
+                z: 999
+
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                text: "/ / Under Construction / /"
+
+                background: Rectangle {
+                    color: Qt.rgba(1, 1, 0, 0.5)
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: { debugDialog.open() }
+                }
+            }
+        }
+    }
+
+    PanelPopup {
+        id: windowedModeLauncher
+
+        property bool visibility: LauncherController.visible && (LauncherController.currentFrame === "WindowedFrame")
+
+        width: 610
+        height: 480
+        popupX: launcher.itemPos.x
+        popupY: launcher.itemPos.y
+
+        WindowedFrame {
+            anchors.fill: parent
+        }
+
+        onVisibilityChanged: function() {
+            if (visibility) {
+                if (!windowedModeLauncher.visible) {
+                    windowedModeLauncher.open()
+                }
+            } else {
+                windowedModeLauncher.close()
+            }
+        }
+    }
+
+    D.DciIcon {
+        id: icon
+        anchors.centerIn: parent
+        name: Applet.iconName
+        scale: Panel.rootObject.dockItemMaxSize * 9 / 14 / Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE
+        // 9:14 (iconSize/dockHeight)
+        sourceSize: Qt.size(Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE, Dock.MAX_DOCK_TASKMANAGER_ICON_SIZE)
+        onXChanged: updateLaunchpadPos()
+        onYChanged: updateLaunchpadPos()
+        Timer {
+            id: toolTipShowTimer
+            interval: 50
+            onTriggered: {
+                var point = Applet.rootObject.mapToItem(null, Applet.rootObject.width / 2, Applet.rootObject.height / 2)
+                toolTip.DockPanelPositioner.bounding = Qt.rect(point.x, point.y, toolTip.width, toolTip.height)
+                toolTip.open()
+            }
+        }
+        TapHandler {
+            acceptedButtons: Qt.LeftButton
+            onTapped: {
+                LauncherController.visible = !LauncherController.visible
+                toolTip.close()
+            }
+        }
+        HoverHandler {
+            onHoveredChanged: {
+                if (hovered) {
+                    toolTipShowTimer.start()
+                } else {
+                    if (toolTipShowTimer.running) {
+                        toolTipShowTimer.stop()
+                    }
+
+                    toolTip.close()
+                }
+            }
+        }
+    }
+}

--- a/shell-launcher-applet/package/metadata.json
+++ b/shell-launcher-applet/package/metadata.json
@@ -1,0 +1,8 @@
+{
+    "Plugin": {
+        "Version": "1.0",
+        "Id": "org.deepin.ds.dock.launcherapplet",
+        "Url": "launcheritem.qml",
+        "Parent": "org.deepin.ds.dock"
+    }
+}

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>launcheritem</name>
+    <message>
+        <location filename="../package/launcheritem.qml" line="108"/>
+        <source>Internet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="110"/>
+        <source>Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="112"/>
+        <source>Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="114"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="116"/>
+        <source>Graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="118"/>
+        <source>Game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="120"/>
+        <source>Office</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="122"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="124"/>
+        <source>Development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="126"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="128"/>
+        <source>Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="138"/>
+        <source>launchpad</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-launchpad_ca.ts
+++ b/translations/dde-launchpad_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_es.ts
+++ b/translations/dde-launchpad_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_fi.ts
+++ b/translations/dde-launchpad_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_hu.ts
+++ b/translations/dde-launchpad_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_pl.ts
+++ b/translations/dde-launchpad_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_pt_BR.ts
+++ b/translations/dde-launchpad_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_ru.ts
+++ b/translations/dde-launchpad_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -14,7 +16,7 @@
     <message>
         <location filename="../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AppItemMenu.qml" line="65"/>

--- a/translations/dde-launchpad_uk.ts
+++ b/translations/dde-launchpad_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AppItemMenu</name>
     <message>

--- a/translations/dde-launchpad_zh_HK.ts
+++ b/translations/dde-launchpad_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -14,7 +16,7 @@
     <message>
         <location filename="../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AppItemMenu.qml" line="65"/>
@@ -90,7 +92,7 @@
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
         <source>Frequently Used</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -98,12 +100,12 @@
     <message>
         <location filename="../launchercontroller.cpp" line="19"/>
         <source>Show launcher (hidden by default)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../launchercontroller.cpp" line="20"/>
         <source>Toggle launcher visibility</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -136,7 +138,7 @@
     <message>
         <location filename="../qml/Main.qml" line="32"/>
         <source>Game</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="34"/>
@@ -161,22 +163,22 @@
     <message>
         <location filename="../qml/Main.qml" line="42"/>
         <source>Others</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="398"/>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="410"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="424"/>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -184,7 +186,7 @@
     <message>
         <location filename="../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -192,12 +194,12 @@
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -205,42 +207,42 @@
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="142"/>
         <source>Computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="153"/>
         <source>Pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="164"/>
         <source>Documents</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="175"/>
         <source>Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="186"/>
         <source>Control Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-launchpad_zh_TW.ts
+++ b/translations/dde-launchpad_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -14,7 +16,7 @@
     <message>
         <location filename="../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AppItemMenu.qml" line="65"/>
@@ -90,7 +92,7 @@
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
         <source>Frequently Used</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -98,12 +100,12 @@
     <message>
         <location filename="../launchercontroller.cpp" line="19"/>
         <source>Show launcher (hidden by default)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../launchercontroller.cpp" line="20"/>
         <source>Toggle launcher visibility</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -136,7 +138,7 @@
     <message>
         <location filename="../qml/Main.qml" line="32"/>
         <source>Game</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="34"/>
@@ -161,22 +163,22 @@
     <message>
         <location filename="../qml/Main.qml" line="42"/>
         <source>Others</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="398"/>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="410"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="424"/>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -184,7 +186,7 @@
     <message>
         <location filename="../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -192,12 +194,12 @@
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -205,42 +207,42 @@
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="142"/>
         <source>Computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="153"/>
         <source>Pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="164"/>
         <source>Documents</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="175"/>
         <source>Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/windowed/SideBar.qml" line="186"/>
         <source>Control Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
将 dde-shell 中的 launcherItem 移自 dde-launchpad 项目，并逐步迁移 dde-launchpad 的 QML 界面到 shell-launcher-applet 中。

与 https://github.com/linuxdeepin/dde-shell/pull/760 直接相关

Log: