### PR TITLE
fix: various issue after initial port to dde-shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ set(TRANSLATION_FILES
 
 qt_add_dbus_adaptor(DBUS_ADAPTER_FILES dbus/org.deepin.dde.Launcher1.xml launchercontroller.h LauncherController)
 
-qt_add_library(liblaunchpad SHARED
+qt_add_library(launchpadcommon SHARED
     ${SOURCE_FILES}
     ${DBUS_ADAPTER_FILES}
     ${RESOURCES}
@@ -126,7 +126,7 @@ qt_add_executable(${BIN_NAME}
     main.cpp
 )
 
-qt_add_qml_module(liblaunchpad
+qt_add_qml_module(launchpadcommon
     URI org.deepin.launchpad
     VERSION 1.0
     RESOURCES qml.qrc
@@ -135,6 +135,7 @@ qt_add_qml_module(liblaunchpad
     QML_FILES
         ${QML_FILES}
 )
+set_target_properties(launchpadcommon PROPERTIES PREFIX "")
 
 qt_add_translations(${BIN_NAME}
     TS_FILES ${TRANSLATION_FILES}
@@ -147,7 +148,7 @@ PRIVATE
     DDE_LAUNCHPAD_VERSION=${CMAKE_PROJECT_VERSION}
 )
 
-target_link_libraries(liblaunchpad PUBLIC
+target_link_libraries(launchpadcommon PUBLIC
     ${DTK_NS}::Core
     ${DTK_NS}::Gui
     Qt::Qml
@@ -164,9 +165,10 @@ target_link_libraries(liblaunchpad PUBLIC
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
-    liblaunchpad
+    launchpadcommon
 )
 
+install(TARGETS launchpadcommon DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${TRANSLATED_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/${BIN_NAME}/translations)
 install(
     FILES dist/org.deepin.dde.shell.launchpad.appdata.xml

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -79,6 +79,7 @@ InputEventItem {
 
         background: Image {
             source: DesktopIntegration.isTreeLand() ? undefined : DesktopIntegration.backgroundUrl
+            sourceSize: Qt.size(width / 3, height / 3)
 
             Rectangle {
                 anchors.fill: parent

--- a/shell-launcher-applet/CMakeLists.txt
+++ b/shell-launcher-applet/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(shell-launcherapplet SHARED
 
 target_link_libraries(shell-launcherapplet PRIVATE
     Dde::Shell
-    liblaunchpad
+    launchpadcommon
 )
 
 ds_install_package(PACKAGE org.deepin.ds.dock.launcherapplet TARGET shell-launcherapplet)

--- a/shell-launcher-applet/launcheritem.cpp
+++ b/shell-launcher-applet/launcheritem.cpp
@@ -5,10 +5,14 @@
 #include "launcheritem.h"
 #include "pluginfactory.h"
 #include "../launchercontroller.h"
+#include <blurhashimageprovider.h>
 
 #include <DDBusSender>
 
 #include <applet.h>
+#include <qmlengine.h>
+
+DS_USE_NAMESPACE
 
 namespace dock {
 
@@ -22,6 +26,8 @@ LauncherItem::LauncherItem(QObject *parent)
 bool LauncherItem::init()
 {
     DApplet::init();
+
+    DQmlEngine().engine()->addImageProvider(QLatin1String("blurhash"), new BlurhashImageProvider);
 
     QDBusConnection connection = QDBusConnection::sessionBus();
     if (!connection.registerService(QStringLiteral("org.deepin.dde.Launcher1")) ||

--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -51,6 +51,26 @@ AppletItem {
         updateLaunchpadPos()
     }
 
+    function decrementPageIndex(pages) {
+        if (pages.currentIndex === 0 && pages.count > 1) {
+            // pages.setCurrentIndex(pages.count - 1)
+        } else {
+            pages.decrementCurrentIndex()
+        }
+
+        closeContextMenu()
+    }
+
+    function incrementPageIndex(pages) {
+        if (pages.currentIndex === pages.count - 1 && pages.count > 1) {
+            // pages.setCurrentIndex(0)
+        } else {
+            pages.incrementCurrentIndex()
+        }
+
+        closeContextMenu()
+    }
+
     property var activeMenu: null
     property Component appContextMenuCom: AppItemMenu { }
     function showContextMenu(obj, model, additionalProps = {}) {


### PR DESCRIPTION
修复多个初版移植到 dde-shell 后引入的问题，包括：

- liblaunchpad 未安装（追加 install 并更改 target 名称）
- 全屏启动器无模糊版背景（补充注册 imageprovider）
- 全屏启动器上下滚轮无法翻页（补充缺失的辅助函数）
- 优化x11下全屏模糊背景的速度与内存占用（减小图片 sourcesize）

Log: