### PR TITLE
fix: update controller visible state when windowed frame focus out

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -235,6 +235,12 @@ AppletItem {
                 windowedModeLauncher.close()
             }
         }
+        onPopupVisibleChanged: function() {
+            if (LauncherController.currentFrame !== "WindowedFrame") return
+            if (popupVisible !== visibility) {
+                LauncherController.visible = popupVisible
+            }
+        }
     }
 
     D.DciIcon {


### PR DESCRIPTION
当小窗口启动器的 Popup 被隐藏时，更新 LauncherController 的状态，避免
下次按下 Meta 或点击启动器图标时无法使启动器重新显示出来。

Log: