### PR TITLE
feat: special context menu for dummy apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(QML_FILES
     ${PROJECT_SOURCE_DIR}/qml/Main.qml
     ${PROJECT_SOURCE_DIR}/qml/FullscreenFrame.qml
     ${PROJECT_SOURCE_DIR}/qml/AppItemMenu.qml
+    ${PROJECT_SOURCE_DIR}/qml/DummyAppItemMenu.qml
     ${PROJECT_SOURCE_DIR}/qml/GridViewContainer.qml
     ${PROJECT_SOURCE_DIR}/qml/DrawerFolder.qml
     ${PROJECT_SOURCE_DIR}/qml/IconItemDelegate.qml
@@ -84,6 +85,7 @@ get_target_property(WINDOWED_QML_FILES launcher-qml-windowed QT_QML_MODULE_QML_F
 #       see also: https://www.qt.io/blog/revisited-i18n-with-cmake
 set(QML_FILES_NEED_TRANSLATION
     qml/AppItemMenu.qml
+    qml/DummyAppItemMenu.qml
     qml/Main.qml
     qml/FullscreenFrame.qml
     ${WINDOWED_QML_FILES}

--- a/qml/DummyAppItemMenu.qml
+++ b/qml/DummyAppItemMenu.qml
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import org.deepin.dtk 1.0
+
+import org.deepin.launchpad 1.0
+import org.deepin.launchpad.models 1.0
+
+Loader {
+    id: root
+
+    property string desktopId
+
+    signal closed()
+
+    Component {
+        id: contextMenuComp
+
+        Menu {
+            id: contextMenu
+            modal: true
+
+            MenuItem {
+                text: qsTr("Install")
+                onTriggered: {
+                    launchApp(root.desktopId)
+                }
+            }
+
+            MenuItem {
+                text: qsTr("Remove")
+                onTriggered: {
+                    DesktopIntegration.uninstallApp(root.desktopId)
+                }
+            }
+
+            onClosed: {
+                root.closed()
+                root.destroy()
+            }
+        }
+    }
+
+    Connections {
+        target: LauncherController
+        function onVisibleChanged(visible) {
+            if (!LauncherController.visible) {
+                item.close()
+            }
+        }
+    }
+
+    asynchronous: true
+    sourceComponent: contextMenuComp
+
+    function popup() {
+        active = true
+    }
+
+    function close() {
+        active = false
+    }
+
+    onStatusChanged: if (status == Loader.Ready) {
+        item.popup()
+    }
+}

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -59,6 +59,7 @@ QtObject {
 
     property var activeMenu: null
     property Component appContextMenuCom: AppItemMenu { }
+    property Component dummyAppContextMenuCom: DummyAppItemMenu {}
     function showContextMenu(obj, model, additionalProps = {}) {
         if (!obj || !obj.Window.window) {
             console.log("obj or obj.Window.window is null")
@@ -66,19 +67,31 @@ QtObject {
         }
         closeContextMenu()
 
-        const menu = appContextMenuCom.createObject(obj.Window.window.contentItem, Object.assign({
-            display: model.display,
-            desktopId: model.desktopId,
-            iconName: model.iconName,
-            isFavoriteItem: false,
-            hideFavoriteMenu: true,
-            hideDisplayScalingMenu: false,
-            hideMoveToTopMenu: true
-        }, additionalProps));
-        menu.closed.connect(menu.destroy)
-        menu.popup();
+        if (!DesktopIntegration.appIsDummyPackage(model.desktopId)) {
+            // Pop a menu for normal apps
+            const menu = appContextMenuCom.createObject(obj.Window.window.contentItem, Object.assign({
+                display: model.display,
+                desktopId: model.desktopId,
+                iconName: model.iconName,
+                isFavoriteItem: false,
+                hideFavoriteMenu: true,
+                hideDisplayScalingMenu: false,
+                hideMoveToTopMenu: true
+            }, additionalProps));
+            menu.closed.connect(menu.destroy)
+            menu.popup();
 
-        activeMenu = menu
+            activeMenu = menu
+        } else {
+            // Pop a simplified menu for dummy apps
+            const menu = dummyAppContextMenuCom.createObject(obj.Window.window.contentItem, Object.assign({
+                desktopId: model.desktopId
+            }), additionalProps);
+            menu.closed.connect(menu.destroy)
+            menu.popup();
+
+            activeMenu = menu
+        }
     }
 
     function closeContextMenu() {

--- a/translations/dde-launchpad.ts
+++ b/translations/dde-launchpad.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,7 +223,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_az.ts
+++ b/translations/dde-launchpad_az.ts
@@ -132,6 +132,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -222,17 +235,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -253,7 +266,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_bo.ts
+++ b/translations/dde-launchpad_bo.ts
@@ -132,6 +132,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -222,17 +235,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -253,7 +266,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_ca.ts
+++ b/translations/dde-launchpad_ca.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Altres</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Segur que voleu desinstal·lar %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Confirmeu-ho</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Totes les aplicacions</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>No hi ha resultats de la cerca.</translation>

--- a/translations/dde-launchpad_es.ts
+++ b/translations/dde-launchpad_es.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Otros</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>¿Estás seguro de que quieres desinstalar %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Todas las aplicaciones</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>No hay resultados</translation>

--- a/translations/dde-launchpad_fi.ts
+++ b/translations/dde-launchpad_fi.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Muut</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Haluatko varmasti poistaa asennuksen %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Vahvista</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Kaikki sovellukset</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Ei hakutuloksia</translation>

--- a/translations/dde-launchpad_fr.ts
+++ b/translations/dde-launchpad_fr.ts
@@ -132,6 +132,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -218,17 +231,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -249,7 +262,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_hu.ts
+++ b/translations/dde-launchpad_hu.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Egyéb</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Biztosan el szeretné távolítani a következőt: %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Megerősítés</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Minden alkalmazás</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Nincs keresési eredmény</translation>

--- a/translations/dde-launchpad_it.ts
+++ b/translations/dde-launchpad_it.ts
@@ -139,6 +139,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -233,17 +246,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -264,7 +277,7 @@
         <translation type="unfinished">Tutte le app</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished">Nessun risultato disponibile</translation>

--- a/translations/dde-launchpad_ja.ts
+++ b/translations/dde-launchpad_ja.ts
@@ -132,6 +132,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -218,17 +231,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -249,7 +262,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_ko.ts
+++ b/translations/dde-launchpad_ko.ts
@@ -132,6 +132,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -218,17 +231,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -249,7 +262,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_nb_NO.ts
+++ b/translations/dde-launchpad_nb_NO.ts
@@ -139,6 +139,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -233,17 +246,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -264,7 +277,7 @@
         <translation type="unfinished">Alle programmer</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished">Ingen søkeresultater</translation>

--- a/translations/dde-launchpad_pl.ts
+++ b/translations/dde-launchpad_pl.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Inne</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Czy na pewno chcesz odinstalować %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Wszystkie aplikacje</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>

--- a/translations/dde-launchpad_pt_BR.ts
+++ b/translations/dde-launchpad_pt_BR.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Outros</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Desinstalar %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Todos os aplicativos</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Nenhum resultado encontrado</translation>

--- a/translations/dde-launchpad_ru.ts
+++ b/translations/dde-launchpad_ru.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Прочее</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Вы уверены, что хотите удалить %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Подтвердить</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Все приложения</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Ничего не найдено</translation>

--- a/translations/dde-launchpad_uk.ts
+++ b/translations/dde-launchpad_uk.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation>Інше</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>Ви справді хочете вилучити %1?</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>
@@ -210,7 +223,7 @@
         <translation>Усі програми</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>

--- a/translations/dde-launchpad_zh_CN.ts
+++ b/translations/dde-launchpad_zh_CN.ts
@@ -147,6 +147,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -241,17 +254,17 @@
         <translation>其他应用</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation>您确定要卸载 %1 吗？</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation>确 定</translation>
     </message>
@@ -272,7 +285,7 @@
         <translation>所有应用</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>

--- a/translations/dde-launchpad_zh_HK.ts
+++ b/translations/dde-launchpad_zh_HK.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,7 +223,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>

--- a/translations/dde-launchpad_zh_TW.ts
+++ b/translations/dde-launchpad_zh_TW.ts
@@ -93,6 +93,19 @@
     </message>
 </context>
 <context>
+    <name>DummyAppItemMenu</name>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="27"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/DummyAppItemMenu.qml" line="34"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>FrequentlyUsedView</name>
     <message>
         <location filename="../qml/windowed/FrequentlyUsedView.qml" line="35"/>
@@ -179,17 +192,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="398"/>
+        <location filename="../qml/Main.qml" line="411"/>
         <source>Are you sure you want to uninstall %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="410"/>
+        <location filename="../qml/Main.qml" line="423"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/Main.qml" line="424"/>
+        <location filename="../qml/Main.qml" line="437"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,7 +223,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="542"/>
+        <location filename="../qml/FullscreenFrame.qml" line="566"/>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
为占位包实现了仅有“安装”和“移除”的右键菜单。
cherry-pick 到维护分支并建立了对应的翻译条目。

Log: 为占位应用图标提供了简单版本的右键菜单。