### PR TITLE
fix: avoid hover animation for grid items

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -13,6 +13,7 @@ import org.deepin.dtk.style 1.0 as DS
 
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
+import 'windowed' as WindowedLaunchpad
 
 InputEventItem {
     anchors.fill: parent
@@ -148,6 +149,9 @@ InputEventItem {
                         ToolTip.visible: hovered
                         ToolTip.delay: 500
                         ToolTip.text: qsTr("Window Mode")
+                        background: WindowedLaunchpad.ItemBackground {
+                            button: exitFullscreenBtn
+                        }
                         onClicked: {
                             searchEdit.text = ""
                             LauncherController.currentFrame = "WindowedFrame"

--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -13,6 +13,7 @@ import org.deepin.dtk.style 1.0 as DS
 
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
+import 'windowed'
 
 Control {
     id: root
@@ -51,9 +52,11 @@ Control {
         }
     }
 
-    contentItem: ToolButton {
+    contentItem: Button {
         focusPolicy: Qt.NoFocus
         ColorSelector.pressed: false
+        ColorSelector.family: D.Palette.CrystalColor
+        flat: true
         contentItem: Column {
             anchors.fill: parent
 
@@ -223,28 +226,9 @@ Control {
         ToolTip.text: root.text
         ToolTip.delay: 500
         ToolTip.visible: hovered && iconItemLabel.truncated
-        background: ButtonPanel {
-            button: parent
-            outsideBorderColor: null
+        background: ItemBackground {
             radius: isWindowedMode ? 8 : 18
-            insideBorderColor: isWindowedMode ? null : DS.Style.button.insideBorder
-
-            property D.Palette background: D.Palette {
-                normal {
-                    common: Qt.rgba(0, 0, 0, 0.1)
-                    crystal: Qt.rgba(0, 0, 0, 0.1)
-                }
-                normalDark {
-                    common: Qt.rgba(1, 1, 1, 0.1)
-                    crystal: Qt.rgba(1, 1, 1, 0.1)
-                }
-                hovered {
-                    common: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
-                    crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
-                }
-            }
-            color1: isWindowedMode ? background : DS.Style.button.background1
-            color2: isWindowedMode ? background : DS.Style.button.background2
+            button: parent
         }
     }
     background: DebugBounding { }

--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -23,10 +23,12 @@ Control {
     signal itemClicked()
     signal menuTriggered()
 
-    contentItem: ToolButton {
+    contentItem: Button {
         id: iconButton
         focusPolicy: Qt.NoFocus
         ColorSelector.pressed: false
+        ColorSelector.family: Palette.CrystalColor
+        flat: true
         contentItem: Column {
             anchors.fill: parent
 


### PR DESCRIPTION
避免 hover 时由 ToolButton 导致的放大动效。

Log: