### PR TITLE
feat: API to check if a package is dummy package

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -108,6 +108,24 @@ bool DesktopIntegration::appIsCompulsoryForDesktop(const QString &desktopId)
     return false;
 }
 
+bool DesktopIntegration::appIsDummyPackage(const QString &desktopId)
+{
+#ifdef NO_APPSTREAM_QT
+    Q_UNUSED(desktopId)
+#else
+    AppStream::Pool pool;
+    // qDebug() << pool.flags();
+    pool.load();
+
+    const AppStream::ComponentBox components = pool.componentsByLaunchable(AppStream::Launchable::KindDesktopId, desktopId);
+    for (const AppStream::Component & component : components) {
+        return component.customValue("DDE::is_dummy_package") == "true";
+    }
+#endif
+
+    return false;
+}
+
 Qt::ArrowType DesktopIntegration::dockPosition() const
 {
     return m_dockIntegration->direction();

--- a/desktopintegration.h
+++ b/desktopintegration.h
@@ -49,6 +49,7 @@ public:
     Q_INVOKABLE static void showFolder(enum QStandardPaths::StandardLocation location);
     Q_INVOKABLE static void showUrl(const QString & url);
     Q_INVOKABLE bool appIsCompulsoryForDesktop(const QString & desktopId);
+    Q_INVOKABLE bool appIsDummyPackage(const QString & desktopId);
     // TODO: async get wallpaper?
 
     Qt::ArrowType dockPosition() const;


### PR DESCRIPTION
实现占位包右键菜单功能时忘记 cherry-pick 这里的实现到维护分支，需要将此提交 cherry-pick 合入后重新集成测试。

支持使用 AppStream 的自定义字段（DDE:is_dummy_package）声明虚拟占位包。

Log: