### PR TITLE
fix: use proper dock DnD MIME data

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -269,9 +269,7 @@ Popup {
                                             anchors.fill: parent
                                             dndEnabled: true
                                             displayFont: isWindowedMode ? DTK.fontManager.t9 : DTK.fontManager.t6
-                                            Drag.mimeData: {
-                                                "text/x-dde-launcher-dnd-desktopId": model.desktopId
-                                            }
+                                            Drag.mimeData: Helper.generateDragMimeData(model.desktopId)
                                             visible: dndItem.currentlyDraggedId !== model.desktopId
                                             iconSource: iconName
 

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -459,9 +459,7 @@ InputEventItem {
                                         margins: 5
                                     }
                                     dndEnabled: !folderGridViewPopup.opened
-                                    Drag.mimeData: {
-                                        "text/x-dde-launcher-dnd-desktopId": model.desktopId
-                                    }
+                                    Drag.mimeData: Helper.generateDragMimeData(model.desktopId)
                                     visible: dndItem.currentlyDraggedId !== model.desktopId
                                     iconSource: (iconName && iconName !== "") ? iconName : "application-x-desktop"
                                     icons: folderIcons

--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -39,4 +39,14 @@ QtObject {
             crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
         }
     }
+
+    function generateDragMimeData(desktopId) {
+        // In some cases an app is not allowed to be pinned onto dock via drag-n-drop;
+        // We only insert the MIME data for dde-dock in those allowed cases.
+        var mime = { "text/x-dde-launcher-dnd-desktopId": desktopId }
+        if (!DesktopIntegration.appIsDummyPackage(desktopId)) {
+            mime["text/x-dde-dock-dnd-appid"] = desktopId
+        }
+        return mime
+    }
 }

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -231,9 +231,7 @@ Item {
                 Drag.hotSpot.y: height / 2
                 Drag.dragType: Drag.Automatic
                 Drag.active: mouseArea.drag.active
-                Drag.mimeData: {
-                    "text/x-dde-launcher-dnd-desktopId": model.desktopId
-                }
+                Drag.mimeData: Helper.generateDragMimeData(model.desktopId)
 
                 background: ItemBackground {
                     id: bg


### PR DESCRIPTION
对于将应用拖拽到Dock上固定的场景使用正确的MIME数据，并在不允许某应用固定到Dock上时不加入此MIME数据，以阻止Dock接受拖拽事件。此提交是占位包需求遗留问题的修复。

此PR目标为主分支，与linuxdeepin/dde-shell#817 互相依赖。

Log:
Bug: https://pms.uniontech.com/bug-view-279155.html