### PR TITLE
fix: Dock can overlapping right-click menu

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -19,6 +19,9 @@ Loader {
     property bool hideFavoriteMenu
     property bool hideMoveToTopMenu
     property bool hideDisplayScalingMenu
+    readonly property bool isFullscreen: LauncherController.currentFrame === "FullscreenFrame"
+    readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
+    readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
 
     signal closed()
 
@@ -27,7 +30,7 @@ Loader {
 
         Menu {
             id: contextMenu
-
+            margins: isFullscreen ? dockSpacing : 0
             modal: true
 
             MenuItem {

--- a/qml/DummyAppItemMenu.qml
+++ b/qml/DummyAppItemMenu.qml
@@ -13,6 +13,9 @@ Loader {
     id: root
 
     property string desktopId
+    readonly property bool isFullscreen: LauncherController.currentFrame === "FullscreenFrame"
+    readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
+    readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
 
     signal closed()
 
@@ -21,6 +24,7 @@ Loader {
 
         Menu {
             id: contextMenu
+            margins: isFullscreen ? dockSpacing : 0
             modal: true
 
             MenuItem {


### PR DESCRIPTION
Add margins to menu. However, the margins cannot be applied to a single direction so that it will be marginned on all the directions.

Bug: https://pms.uniontech.com/bug-view-277989.html
Log: Dock can overlapping right-click menu