### PR TITLE
fix: Set menu margin according to dock location

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -30,7 +30,10 @@ Loader {
 
         Menu {
             id: contextMenu
-            margins: isFullscreen ? dockSpacing : 0
+            topMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.UpArrow ? dockSpacing : 0
+            bottomMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.DownArrow ? dockSpacing : 0
+            leftMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.LeftArrow ? dockSpacing : 0
+            rightMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.RightArrow ? dockSpacing : 0
             modal: true
 
             MenuItem {

--- a/qml/DummyAppItemMenu.qml
+++ b/qml/DummyAppItemMenu.qml
@@ -24,7 +24,10 @@ Loader {
 
         Menu {
             id: contextMenu
-            margins: isFullscreen ? dockSpacing : 0
+            topMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.UpArrow ? dockSpacing : 0
+            bottomMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.DownArrow ? dockSpacing : 0
+            leftMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.LeftArrow ? dockSpacing : 0
+            rightMargin: isFullscreen && DesktopIntegration.dockPosition == Qt.RightArrow ? dockSpacing : 0
             modal: true
 
             MenuItem {


### PR DESCRIPTION
Somehow, the Menu QML document doesn't mention the common margin option per directions.

Bug: https://pms.uniontech.com/bug-view-277989.html
Log: Set menu margin according to dock location