### PR TITLE
fix: windowed mode search result has incorrect alignment

### DIFF
--- a/qml/windowed/SearchResultView.qml
+++ b/qml/windowed/SearchResultView.qml
@@ -62,8 +62,8 @@ Control {
             Layout.alignment: Qt.AlignRight
             Layout.topMargin: 10
             Layout.rightMargin: 10
-            Layout.preferredHeight: searchResultViewContainer.height
-            Layout.preferredWidth: searchResultViewContainer.width - 10
+            Layout.fillHeight: true
+            Layout.fillWidth: true
             interactive: true
 
             model: delegateSearchResultModel


### PR DESCRIPTION
修复 Qt 6.8 下，小窗口启动器搜索结果视图对齐不正确的问题。

Log: