### PR TITLE
chore: release dde-launchpad 1.0.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-launchpad (1.0.7) unstable; urgency=medium
+
+  * backport Qt 6.8 fix for release branch
+
+ -- Wang Zichong <wangzichong@deepin.org>  Thu, 07 Nov 2024 10:59:00 +0800
+
 dde-launchpad (1.0.6) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Desktop Environment (#453)


### PR DESCRIPTION
发布 1.0.7 版本。

注：此版本实质和 1.0.6 无差异，但 deepin 仓库集成的版本和实际落下的
tag 差了一个 commit（内容是 6.8 的一个 fix），所以仍然需要 bump 版本号。

Log: