### PR TITLE
fix: Launchpad blurry background will never adapt to secondary monitor

### DIFF
--- a/src/ddeintegration/appearance.cpp
+++ b/src/ddeintegration/appearance.cpp
@@ -88,11 +88,10 @@ void Appearance::updateAllWallpaper()
     if (!doc.isObject()) {
         return;
     }
-    int i = 1;
-    do {
-        const QString k = QString("Primary&&%1").arg(i++);
-        QJsonValue v = doc[k];
 
+    for (auto it = doc.object().begin(); it != doc.object().end(); ++it) {
+        QString k = it.key();
+        QJsonValue v = it.value();
 #ifdef QT_DEBUG
         qDebug() << k << ":" << v;
 #endif
@@ -135,7 +134,7 @@ void Appearance::updateAllWallpaper()
         });
 
         m_blurhashWatchers << watcher;
-    } while(1);
+    }
 }
 
 qreal Appearance::opacity() const


### PR DESCRIPTION
Secondary monitor backgrounds were not included.

Bug: https://pms.uniontech.com/bug-view-279127.html
Log: Launchpad blurry background will never adapt to secondary monitor