### PR TITLE
chore: update current unit test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,11 +9,12 @@ qt_standard_project_setup()
 macro(launchpad_add_tests)
     foreach(_testname ${ARGN})
         qt_add_executable(launchpad-${_testname} ${_testname}.cpp)
-        target_link_libraries(launchpad-${_testname} PRIVATE Qt6::Core Qt6::Test launcher-models)
+        target_link_libraries(launchpad-${_testname} PRIVATE Qt6::Core Qt6::Test launchpadcommon)
         add_test(NAME launchpad-${_testname} COMMAND launchpad-${_testname})
     endforeach()
 endmacro()
 
 launchpad_add_tests(
     itemspagetest
+    gioappinfotest
 )

--- a/tests/gioappinfotest.cpp
+++ b/tests/gioappinfotest.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QTest>
+
+#include "appinfo.h"
+
+class TestGioAppInfo: public QObject
+{
+    Q_OBJECT
+private slots:
+    void dfmInfo();
+};
+
+void TestGioAppInfo::dfmInfo()
+{
+    QString path = AppInfo::fullPathByDesktopId("dde-file-manager.desktop");
+    QVERIFY(QFile::exists(path));
+    QVERIFY(!path.isEmpty());
+}
+
+QTEST_MAIN(TestGioAppInfo)
+#include "gioappinfotest.moc"


### PR DESCRIPTION
由于结构调整，目前的单元测试构建失效了。这个提交修复了这个问题，
并补充了一个简单测试。

Log: