### PR TITLE
fix: launchpad crash at josn2value

### DIFF
--- a/src/ddeintegration/appearance.cpp
+++ b/src/ddeintegration/appearance.cpp
@@ -89,7 +89,8 @@ void Appearance::updateAllWallpaper()
         return;
     }
 
-    for (auto it = doc.object().begin(); it != doc.object().end(); ++it) {
+    auto obj = doc.object();
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
         QString k = it.key();
         QJsonValue v = it.value();
 #ifdef QT_DEBUG


### PR DESCRIPTION
QJsonDocument::object get a value object instead of a reference/pointer

log: as title