### PR TITLE
fix: FrequentlyUsedView and RecentlyInstalledView icons not-clickable

### DIFF
--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -127,10 +127,6 @@ Control {
             radius: 8
             button: iconButton
         }
-
-        onClicked: {
-            root.itemClicked()
-        }
     }
     background: DebugBounding { }
 
@@ -138,6 +134,14 @@ Control {
         acceptedButtons: Qt.RightButton
         onTapped: {
             root.menuTriggered()
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.LeftButton
+        gesturePolicy: TapHandler.WithinBounds
+        onTapped: {
+            root.itemClicked()
         }
     }
 


### PR DESCRIPTION
不可排序区域的图标拖拽功能添加的 DragHandler 导致 Button 的 click 被抢，导致只有图标外的区域的点击才有效。此修复选择了和全屏启动器相同的方案处理此问题，即另加一个 TapHandler 来处理点击事件。

Log: