### PR TITLE
fix: add missing translation for launcher item tooltip

### DIFF
--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
@@ -337,7 +337,7 @@
     <message>
         <location filename="../package/launcheritem.qml" line="140"/>
         <source>launchpad</source>
-        <translation type="unfinished"></translation>
+        <translation>启动器</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="268"/>


### PR DESCRIPTION
任务栏上的启动器图标 hover tooltip 未提供翻译，此提交追加了相应翻译

PMS: BUG-278083
Log: