### PR TITLE
fix: stop freefrom sort view scrolling when drag finished

### DIFF
--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -158,12 +158,6 @@ Item {
                 }
             }
 
-            Drag.onActiveChanged: function(active) {
-                if (!active) {
-                    listViewDragScroller.stopScroll()
-                }
-            }
-
             onPositionChanged: function(drag) {
                 let dragId = drag.getDataAsString("text/x-dde-launcher-dnd-desktopId")
                 if (dragId === desktopId) {
@@ -242,6 +236,11 @@ Item {
                 Drag.dragType: Drag.Automatic
                 Drag.active: mouseArea.drag.active
                 Drag.mimeData: Helper.generateDragMimeData(model.desktopId)
+                Drag.onActiveChanged: function() {
+                    if (!Drag.active) {
+                        listViewDragScroller.stopScroll()
+                    }
+                }
 
                 background: ItemBackground {
                     id: bg


### PR DESCRIPTION
当鼠标释放拖拽时即停止滚动。之前因为 attached property 所设对象不对所以没有生效（可能是曾有过层级关系调整导致的）。

Log: