### PR TITLE
fix: x11 launchpad can not hide

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -325,11 +325,17 @@ AppletItem {
                 toolTip.open()
             }
         }
-        TapHandler {
-            acceptedButtons: Qt.LeftButton
-            onTapped: {
-                LauncherController.visible = !LauncherController.visible
-                toolTip.close()
+
+        // FIXME: The TapHandler receives the event after visibleChange, which causes the state to be inverted after synchronization,
+        // causing the launchpad to be displayed again. However, the MouseArea receives the event before visibleChange.
+        MouseArea {
+            id: mouseHandler
+            anchors.fill: parent
+            onClicked: function (mouse) {
+                if (mouse.button === Qt.LeftButton) {
+                    LauncherController.visible = !LauncherController.visible
+                    toolTip.close()
+                }
             }
         }
         HoverHandler {


### PR DESCRIPTION
x11下连续点启动器，应该可以正常的隐藏和显示
treeland点击快捷面板再点击启动器，启动器可以正常的显示

使用taphandler时都不行