### PR TITLE
chore: release dde-launchpad 1.99.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-launchpad (1.99.3) UNRELEASED; urgency=medium
+
+  * Show autostart icons for items in freeform-sort view
+  * Fix icons in some view are not clickable
+  * Add missing translation for launchpad icon on taskbar area
+  * Stop scrolling when freeform-sort view item drag finished
+  * Update tooltip delay time
+  * Fix x11 launchpad cannot hide
+
+ -- Wang Zichong <wangzichong@deepin.org>  Fri, 06 Dec 2024 16:13:00 +0800
+
 dde-launchpad (1.99.2) UNRELEASED; urgency=medium
 
   * support most areas apps drop to dock (PMS-285139)


### PR DESCRIPTION
  * Show autostart icons for items in freeform-sort view
  * Fix icons in some view are not clickable
  * Add missing translation for launchpad icon on taskbar area
  * Stop scrolling when freeform-sort view item drag finished
  * Update tooltip delay time
  * Fix x11 launchpad cannot hide

Log: