### PR TITLE
fix: Hide launchpad window as soon as launching Apps

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -132,6 +132,7 @@ AppletItem {
     }
 
     function launchApp(desktopId) {
+        LauncherController.visible = false;
         DesktopIntegration.launchByDesktopId(desktopId);
     }
 


### PR DESCRIPTION
Avoiding showing app organizating animation.

pms: BUG-286727
Log: Hide launchpad window as soon as launching Apps