### PR TITLE
fix: hover background for category list view items

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -289,7 +289,7 @@ FocusScope {
             }
 
             background: Loader {
-                active: itemDelegate.ListView.view.bgVisible === undefined
+                active: !dragHandler.active
                 sourceComponent: ItemBackground {
                     implicitWidth: DStyle.Style.itemDelegate.width
                     implicitHeight: Helper.windowed.listItemHeight


### PR DESCRIPTION
修复分类列表模式的项目hover背景不显示的问题。

注意：当前dtkdeclarative存在问题，拖拽并释放后会导致hover残留，需要从dtkdeclarative一侧修复。