### PR TITLE
fix: the search results are displayed in the middle

### DIFF
--- a/qml/windowed/SearchResultView.qml
+++ b/qml/windowed/SearchResultView.qml
@@ -62,8 +62,8 @@ Control {
             Layout.alignment: Qt.AlignRight
             Layout.topMargin: 10
             Layout.rightMargin: 10
-            Layout.fillHeight: true
-            Layout.fillWidth: true
+            Layout.preferredHeight: searchResultViewContainer.height
+            Layout.preferredWidth: searchResultViewContainer.width
             interactive: true
 
             model: delegateSearchResultModel


### PR DESCRIPTION
Modify the recommended size of GridViewContainer

pms: Bug-291293