### PR TITLE
fix(UI): add a footer for windowed mode list view for padding

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -348,6 +348,11 @@ FocusScope {
             }
         }
 
+        // End margin, see PMS-301113
+        footer: Item {
+            height: 10
+        }
+
         model: delegateCategorizedModel
 
         ScrollBar.vertical: ScrollBar { }

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -48,6 +48,11 @@ Item {
             }
         }
 
+        // End margin, see PMS-301113
+        footer: Item {
+            height: 10
+        }
+
         onActiveFocusChanged: {
             if (activeFocus) {
                 listView.currentIndex = 0


### PR DESCRIPTION
为窗口模式的两个列表视图增加 footer,旨在增加滚动到底部后末端增加空白 padding.

PMS: BUG-301113