### PR TITLE
fix: can't search polyphonic characters

### DIFF
--- a/src/models/appsmodel.cpp
+++ b/src/models/appsmodel.cpp
@@ -190,6 +190,12 @@ QVariant AppsModel::data(const QModelIndex &index, int role) const
         else if (!firstChar.isLetter()) return QString("&%1").arg(transliterated);
         return transliterated;
     }
+    case AppsModel::AllTransliteratedRole: {
+        // it's useful to search(e.g. Music: YinYue or YinLe -> YinYueYinLe)
+        const auto decodedDisplay = Dtk::Core::pinyin(index.data(Qt::DisplayRole).toString(), Dtk::Core::TS_NoneTone);
+        const QString &transliterated = decodedDisplay.join(".");
+        return transliterated;
+    }
     default:
         break;
     }

--- a/src/models/appsmodel.h
+++ b/src/models/appsmodel.h
@@ -25,6 +25,7 @@ class AppsModel : public QStandardItemModel
 public:
     enum Roles {
         TransliteratedRole = AppItem::ModelExtendedRole,
+        AllTransliteratedRole,
         NameRole = AppItem::NameRole,
         ProxyModelExtendedRole = 0x10000
     };

--- a/src/models/searchfilterproxymodel.cpp
+++ b/src/models/searchfilterproxymodel.cpp
@@ -25,7 +25,7 @@ bool SearchFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &
 
     const QString & displayName = modelIndex.data(Qt::DisplayRole).toString();
     const QString & name = modelIndex.data(AppsModel::NameRole).toString();
-    const QString & transliterated = modelIndex.data(AppsModel::TransliteratedRole).toString();
+    const QString & transliterated = modelIndex.data(AppsModel::AllTransliteratedRole).toString();
     const QString & jianpin = Dtk::Core::firstLetters(displayName).join(',');
 
     auto nameCopy = name;


### PR DESCRIPTION
dtk::core::pinyin() returns all polyphonic characters, but it's
not used in transliterated.
We use all polyphonic characters to match searchPattern instead of
first word.

pms: BUG-288487
