### PR TITLE
fix: assign fullscreen frame screen on init completed

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -51,6 +51,7 @@ AppletItem {
     }
     Component.onCompleted: {
         updateLaunchpadPos()
+        assignFullscreenFrameScreen()
     }
 
     function decrementPageIndex(pages) {


### PR DESCRIPTION
用户存在多个屏幕时,ApplicationWindow.screen默认值可能不是主屏.故在
初始化组件完成后即设置一次全屏启动器所使用的屏幕,确保和主屏相符.

PMS: BUG-300309
Log: