### PR TITLE
fix: incorrect selectedTextColor for folderPopup

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -109,7 +109,6 @@ Popup {
 
                     // TODO: selectionColor will work after dtkdeclarative fix background blur isssues
                     selectionColor: palette.highlight
-                    selectedTextColor: isWindowedMode ? "black" : "white"
                 }
                 Text {
                     id: folderNameText


### PR DESCRIPTION
it's exist in windowed Mode,
according UI designer, selectedTextColor is white whether it's
in windowed Mode or full Mode.

pms: BUG-301103
