### PR TITLE
fix: add base locale as fallback for app display name

### DIFF
--- a/src/ddeintegration/appmgr.cpp
+++ b/src/ddeintegration/appmgr.cpp
@@ -18,7 +18,8 @@ Q_CONSTRUCTOR_FUNCTION(registerComplexDbusType);
 static QString parseDisplayName(const QStringMap &source)
 {
     static QString key = QLocale::system().name();
-    return source.value(key, source.value(u8"default"));
+    const QString & defaultValue = source.value(u8"default");
+    return source.value(key, key.contains('_') ? source.value(key.split('_')[0], defaultValue) : defaultValue);
 }
 
 static QString parseName(const QStringMap &source)


### PR DESCRIPTION
为应用名称的获取增加上一级 locale 作为 fallback，例如 es_ES 为空时，应当尝试 es 作为 fallback，若仍然为空再使用 default。

Log:

## Summary by Sourcery

Bug Fixes:
- Adds a fallback to retrieve the application display name.