### PR TITLE
fix: Modify dragapp behind dropapp.

### DIFF
--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -132,7 +132,7 @@ void ItemArrangementProxyModel::commitDndOperation(const QString &dragId, const 
             // make a new folder, move two items into the folder
             QString dstFolderId = findAvailableFolderId();
             ItemsPage * dstFolder = createFolder(dstFolderId);
-            dstFolder->appendPage({dragId, dropId});
+            dstFolder->appendPage({dropId, dragId});
             AppItem * dropItem = AppsModel::instance().itemFromDesktopId(dropId);
             AppItem::DDECategories dropCategories = AppItem::DDECategories(CategoryUtils::parseBestMatchedCategory(dropItem->categories()));
             dstFolder->setName("internal/category/" + QString::number(dropCategories));


### PR DESCRIPTION
swap dragId and dropId

PMS-BUG-288919

## Summary by Sourcery

Bug Fixes:
- Fix the order of items when creating a new folder during drag and drop, ensuring the correct item placement