### PR TITLE
fix: clicking the left and right keys no response in fullscreen.

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -677,6 +677,8 @@ InputEventItem {
                 switch (event.key) {
                 case Qt.Key_Up:
                 case Qt.Key_Down:
+                case Qt.Key_Left:
+                case Qt.Key_Right:
                 case Qt.Key_Enter:
                 case Qt.Key_Return:
                     listviewPage.focus = true


### PR DESCRIPTION
event added the key_right and key_left.

pms-bug-289091

## Summary by Sourcery

Bug Fixes:
- Enable Left and Right arrow keys to correctly set focus to the list view when in fullscreen.