### PR TITLE
chore: release dde-launchpad 1.99.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-launchpad (1.99.12) UNRELEASED; urgency=medium
+
+  * fix: clicking the left and right keys no response in fullscreen.
+  * fix: The title text of launcher application group fontbold
+  * Update translations from Transifex
+
+-- Wu Jiangyu <wujiangyu@uniontech.com>  Tue, 29 Apr 2025 11:14:000 +0800
+
 dde-launchpad (1.99.11) UNRELEASED; urgency=medium
 
   * fix: add base locale as fallback for app display name (Bug-310179)


### PR DESCRIPTION
fix: clicking the left and right keys no response in fullscreen.(BUG-289091) fix: The title text of launcher application group fontbold.(BUG-307811) Update translations from Transifex

Log: release dde-launchpad 1.99.12

## Summary by Sourcery

Build:
- Update debian/changelog with details for version 1.99.12.