### PR TITLE
fix: Add quotation marks to the app name in the uninstall dialog

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -397,7 +397,7 @@ QtObject {
             spacing: 0
             Label {
                 font: DTK.fontManager.t5
-                text: qsTr("Are you sure you want to uninstall %1?").arg(confirmUninstallDlg.appName)
+                text: qsTr("Are you sure you want to uninstall \"%1\"?").arg(confirmUninstallDlg.appName)
                 wrapMode: Text.Wrap
                 horizontalAlignment: Text.AlignHCenter
                 Layout.preferredWidth: 400

--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -306,7 +306,7 @@ AppletItem {
             spacing: 0
             Label {
                 font: DTK.fontManager.t5
-                text: qsTr("Are you sure you want to uninstall %1?").arg(confirmUninstallDlg.appName)
+                text: qsTr("Are you sure you want to uninstall \"%1\"?").arg(confirmUninstallDlg.appName)
                 wrapMode: Text.Wrap
                 horizontalAlignment: Text.AlignHCenter
                 Layout.preferredWidth: 400

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -180,7 +180,7 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
@@ -327,17 +327,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -77,12 +79,12 @@
     <message>
         <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Pencərə rejimi</translation>
     </message>
@@ -124,27 +126,27 @@
     <message>
         <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="32"/>
@@ -154,22 +156,22 @@
     <message>
         <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="42"/>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>%1 cıxartmaq istəyirsiniz?
+        <translation type="vanished">%1 cıxartmaq istəyirsiniz?
 </translation>
     </message>
     <message>
@@ -209,7 +215,7 @@
         <translation>Bütün uquanlar</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Axtarış nəticəsi tapılmadı</translation>
@@ -268,27 +274,27 @@
     <message>
         <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="121"/>
@@ -298,22 +304,22 @@
     <message>
         <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="131"/>
@@ -326,18 +332,22 @@
         <translation>launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>%1 cıxış etmək istəyirsiniz?
+        <translation type="vanished">%1 cıxış etmək istəyirsiniz?
 </translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Təsdiq et</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
@@ -159,7 +159,7 @@
         <translation type="obsolete">བཤེར་འཚོལ།</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -223,7 +223,7 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -253,7 +253,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
@@ -385,17 +385,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Mode de finestra</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Segur que voleu desinstal·lar %1?</translation>
+        <translation type="vanished">Segur que voleu desinstal·lar %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Totes les aplicacions</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>No hi ha resultats de la cerca.</translation>
@@ -325,17 +331,21 @@
         <translation>plataforma de llançament</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>Segur que voleu desinstal·lar %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">Segur que voleu desinstal·lar %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Confirmeu-ho</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Modo ventana</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>¿Seguro desea desinstalar %1?</translation>
+        <translation type="vanished">¿Seguro desea desinstalar %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Todas las aplicaciones</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Sin resultados</translation>
@@ -325,17 +331,21 @@
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>¿Seguro desea desinstalar %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">¿Seguro desea desinstalar %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Ikkunatila</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Haluatko poistaa asennuksen %1?</translation>
+        <translation type="vanished">Haluatko poistaa asennuksen %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Kaikki sovellukset</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Ei hakutuloksia</translation>
@@ -325,17 +331,21 @@
         <translation>launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>Haluatko poistaa asennuksen %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">Haluatko poistaa asennuksen %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Vahvista</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Mode de fenêtre</translation>
     </message>
@@ -149,7 +151,7 @@
     <message>
         <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="34"/>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Êtes-vous sûr de vouloir désinstaller %1 ? </translation>
+        <translation type="vanished">Êtes-vous sûr de vouloir désinstaller %1 ? </translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Toutes les application</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Aucun résultat trouvé</translation>
@@ -267,77 +273,77 @@
     <message>
         <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Internet</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Discussion</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Musique</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Vidéo</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Graphiques</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bureautique</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Lecture</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Développement</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Système</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Autres</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation type="unfinished"/>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Confirmer</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Ablak Mód</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Biztosan el szeretné távolítani a következőt: %1?</translation>
+        <translation type="vanished">Biztosan el szeretné távolítani a következőt: %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Minden alkalmazás</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Nincs keresési eredmény</translation>
@@ -325,17 +331,21 @@
         <translation>indítópult</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>Biztosan eltávolítja a következőt: %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">Biztosan eltávolítja a következőt: %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Mégse</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Megerősít</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
@@ -170,7 +170,7 @@
         <translation type="obsolete">Cerca</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -234,7 +234,7 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -264,7 +264,7 @@
         <translation type="unfinished">Tutte le app</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished">Nessun risultato disponibile</translation>
@@ -408,17 +408,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>ウィンドウ モード</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>%1 をアンインストールしてもよろしいですか？</translation>
+        <translation type="vanished">%1 をアンインストールしてもよろしいですか？</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>すべてのアプリ</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>検索結果はありません</translation>
@@ -325,17 +331,21 @@
         <translation>ランチャー</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>%1 をアンインストールしてもよろしいですか？</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">%1 をアンインストールしてもよろしいですか？</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
@@ -155,7 +155,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -219,7 +219,7 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -249,7 +249,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
@@ -381,17 +381,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
@@ -170,7 +170,7 @@
         <translation type="obsolete">Søk</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -234,7 +234,7 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -264,7 +264,7 @@
         <translation type="unfinished">Alle programmer</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished">Ingen søkeresultater</translation>
@@ -408,17 +408,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Tryb okna</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Czy na pewno chcesz odinstalować %1?</translation>
+        <translation type="vanished">Czy na pewno chcesz odinstalować %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Wszystkie aplikacje</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>
@@ -325,17 +331,21 @@
         <translation>Launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>Czy na pewno chcesz odinstalować %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">Czy na pewno chcesz odinstalować %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Modo janela</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Desinstalar %1?</translation>
+        <translation type="vanished">Desinstalar %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Todos os aplicativos</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Nenhum resultado encontrado</translation>
@@ -325,17 +331,21 @@
         <translation>Plataforma de lançamento</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>Tem certeza de que deseja desinstalar %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">Tem certeza de que deseja desinstalar %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -14,7 +16,7 @@
     <message>
         <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/AppItemMenu.qml" line="65"/>
@@ -95,7 +97,7 @@
     <message>
         <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
@@ -114,9 +116,9 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -149,7 +151,7 @@
     <message>
         <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="34"/>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Вы уверены, что хотите удалить %1?</translation>
+        <translation type="vanished">Вы уверены, что хотите удалить %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Все приложения</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Ничего не найдено</translation>
@@ -267,77 +273,77 @@
     <message>
         <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Интернет</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Чат</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Музыка</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Видео</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Графика</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Офис</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Чтение</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Разработка</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Система</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Прочее</translation>
     </message>
     <message>
         <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation type="unfinished"/>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Подтвердить</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Режим вікна</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Ви справді хочете вилучити %1?</translation>
+        <translation type="vanished">Ви справді хочете вилучити %1?</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>Усі програми</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>
@@ -325,17 +331,21 @@
         <translation>пусковий стіл</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>Ви справді хочете вилучити %1?</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">Ви справді хочете вилучити %1?</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>窗口模式</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您确定要卸载 %1 吗？</translation>
+        <translation type="vanished">您确定要卸载 %1 吗？</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>所有应用</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>
@@ -325,17 +331,21 @@
         <translation>启动器</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
-        <source>Are you sure you want to uninstall %1?</source>
-        <translation>您确定要卸载 %1 吗？</translation>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <source>Are you sure you want to uninstall %1?</source>
+        <translation type="vanished">您确定要卸载 %1 吗？</translation>
+    </message>
+    <message>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>确 定</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>窗口模式</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您確定要卸載 %1 嗎？</translation>
+        <translation type="vanished">您確定要卸載 %1 嗎？</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>所有應用</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>無搜索結果</translation>
@@ -322,20 +328,24 @@
     <message>
         <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您確定要卸載 %1 嗎？</translation>
+        <translation type="vanished">您確定要卸載 %1 嗎？</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>確 定</translation>
     </message>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -114,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>視窗模式</translation>
     </message>
@@ -178,8 +180,12 @@
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您確定要移除 %1 嗎？</translation>
+        <translation type="vanished">您確定要移除 %1 嗎？</translation>
     </message>
     <message>
         <location filename="../../qml/Main.qml" line="412"/>
@@ -208,7 +214,7 @@
         <translation>所有應用</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
         <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>無搜尋結果</translation>
@@ -322,20 +328,24 @@
     <message>
         <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="299"/>
+        <location filename="../package/launcheritem.qml" line="309"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您確定要移除 %1 嗎？</translation>
+        <translation type="vanished">您確定要移除 %1 嗎？</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="311"/>
+        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="325"/>
+        <location filename="../package/launcheritem.qml" line="335"/>
         <source>Confirm</source>
         <translation>確 定</translation>
     </message>

--- a/translations/dde-launchpad.ts
+++ b/translations/dde-launchpad.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -193,7 +193,7 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -224,7 +224,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-launchpad_az.ts
+++ b/translations/dde-launchpad_az.ts
@@ -159,7 +159,7 @@
         <translation type="obsolete">Axtar</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -236,7 +236,7 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-launchpad_bo.ts
+++ b/translations/dde-launchpad_bo.ts
@@ -159,7 +159,7 @@
         <translation type="obsolete">བཤེར་འཚོལ།</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -236,7 +236,7 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -267,7 +267,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-launchpad_ca.ts
+++ b/translations/dde-launchpad_ca.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Mode de finestra</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Segur que voleu desinstal·lar %1?</translation>
+        <translation type="vanished">Segur que voleu desinstal·lar %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>No hi ha resultats de la cerca.</translation>
     </message>

--- a/translations/dde-launchpad_es.ts
+++ b/translations/dde-launchpad_es.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Modo ventana</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>¿Seguro que desea desinstalar %1?</translation>
+        <translation type="vanished">¿Seguro que desea desinstalar %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>No hay resultados</translation>
     </message>

--- a/translations/dde-launchpad_fi.ts
+++ b/translations/dde-launchpad_fi.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Ikkunatila</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Haluatko poistaa asennuksen %1?</translation>
+        <translation type="vanished">Haluatko poistaa asennuksen %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Ei hakutuloksia</translation>
     </message>

--- a/translations/dde-launchpad_fr.ts
+++ b/translations/dde-launchpad_fr.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Mode de fenêtre</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Êtes-vous sûr de vouloir désinstaller %1 ? </translation>
+        <translation type="vanished">Êtes-vous sûr de vouloir désinstaller %1 ? </translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Aucun résultat trouvé</translation>
     </message>

--- a/translations/dde-launchpad_hu.ts
+++ b/translations/dde-launchpad_hu.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Ablak Mód</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Biztosan el szeretné távolítani a következőt: %1?</translation>
+        <translation type="vanished">Biztosan el szeretné távolítani a következőt: %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>

--- a/translations/dde-launchpad_it.ts
+++ b/translations/dde-launchpad_it.ts
@@ -170,7 +170,7 @@
         <translation type="obsolete">Cerca</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -247,7 +247,7 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -278,7 +278,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation type="unfinished">Nessun risultato disponibile</translation>
     </message>

--- a/translations/dde-launchpad_ja.ts
+++ b/translations/dde-launchpad_ja.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>ウィンドウ モード</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>%1 をアンインストールしてもよろしいですか？</translation>
+        <translation type="vanished">%1 をアンインストールしてもよろしいですか？</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>検索結果はありません</translation>
     </message>

--- a/translations/dde-launchpad_ko.ts
+++ b/translations/dde-launchpad_ko.ts
@@ -155,7 +155,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -232,7 +232,7 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -263,7 +263,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-launchpad_nb_NO.ts
+++ b/translations/dde-launchpad_nb_NO.ts
@@ -170,7 +170,7 @@
         <translation type="obsolete">Søk</translation>
     </message>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -247,7 +247,7 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall %1?</source>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -278,7 +278,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation type="unfinished">Ingen søkeresultater</translation>
     </message>

--- a/translations/dde-launchpad_pl.ts
+++ b/translations/dde-launchpad_pl.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Tryb okna</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Czy na pewno chcesz odinstalować %1?</translation>
+        <translation type="vanished">Czy na pewno chcesz odinstalować %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>
     </message>

--- a/translations/dde-launchpad_pt_BR.ts
+++ b/translations/dde-launchpad_pt_BR.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Modo de janela</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Desinstalar %1?</translation>
+        <translation type="vanished">Desinstalar %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Nenhum resultado encontrado</translation>
     </message>

--- a/translations/dde-launchpad_ru.ts
+++ b/translations/dde-launchpad_ru.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Вы уверены, что хотите удалить %1?</translation>
+        <translation type="vanished">Вы уверены, что хотите удалить %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Ничего не найдено</translation>
     </message>

--- a/translations/dde-launchpad_uk.ts
+++ b/translations/dde-launchpad_uk.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Режим вікна</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>Ви справді хочете вилучити %1?</translation>
+        <translation type="vanished">Ви справді хочете вилучити %1?</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>
     </message>

--- a/translations/dde-launchpad_zh_CN.ts
+++ b/translations/dde-launchpad_zh_CN.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>窗口模式</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您确定要卸载 %1 吗？</translation>
+        <translation type="vanished">您确定要卸载 %1 吗？</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>
     </message>

--- a/translations/dde-launchpad_zh_HK.ts
+++ b/translations/dde-launchpad_zh_HK.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>窗口模式</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您確定要卸載 %1 嗎？</translation>
+        <translation type="vanished">您確定要卸載 %1 嗎？</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>無搜索結果</translation>
     </message>

--- a/translations/dde-launchpad_zh_TW.ts
+++ b/translations/dde-launchpad_zh_TW.ts
@@ -116,7 +116,7 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../qml/FullscreenFrame.qml" line="163"/>
+        <location filename="../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>視窗模式</translation>
     </message>
@@ -193,8 +193,12 @@
     </message>
     <message>
         <location filename="../qml/Main.qml" line="400"/>
+        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Are you sure you want to uninstall %1?</source>
-        <translation>您確定要移除 %1 嗎？</translation>
+        <translation type="vanished">您確定要移除 %1 嗎？</translation>
     </message>
     <message>
         <location filename="../qml/Main.qml" line="412"/>
@@ -224,7 +228,7 @@
     </message>
     <message>
         <location filename="../qml/windowed/SearchResultView.qml" line="102"/>
-        <location filename="../qml/FullscreenFrame.qml" line="556"/>
+        <location filename="../qml/FullscreenFrame.qml" line="557"/>
         <source>No search results</source>
         <translation>無搜尋結果</translation>
     </message>


### PR DESCRIPTION
add "" for app uninstall

pms-bug-315259

## Summary by Sourcery

Bug Fixes:
- Fixed uninstall dialog text to properly format the app name with quotation marks