### PR TITLE
fix: Apply the list module text color and hover effect adjustments

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -239,7 +239,9 @@ FocusScope {
                     z: 1
                 }
                 font: DTK.fontManager.t8
-                palette.windowText: ListView.view.palette.brightText
+                ColorSelector.pressed: false
+                property Palette textColor: DStyle.Style.button.text
+                palette.windowText: ColorSelector.textColor
                 ToolTip.text: text
                 ToolTip.delay: 500
                 ToolTip.visible: hovered && contentItem.implicitWidth > contentItem.width

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -260,7 +260,9 @@ Item {
                     rightMargin: 10
                 }
                 font: DTK.fontManager.t8
-                palette.windowText: parent.palette.brightText
+                ColorSelector.pressed: false
+                property Palette textColor: DStyle.Style.button.text
+                palette.windowText: ColorSelector.textColor
                 visible: !Drag.active
 
                 ToolTip.text: text


### PR DESCRIPTION
update when hovered, app palette from 70% to 100%

pms-bug-314399

## Summary by Sourcery

Adjust text color opacity for list module items to improve visual appearance

Bug Fixes:
- Fix text visibility in AppListView and FreeSortListView by implementing dynamic text opacity

Enhancements:
- Modify text color to have 70% opacity when not hovered, and 100% opacity when hovered in list views