### PR TITLE
chore: release dde-launchpad 1.99.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-launchpad (1.99.13) UNRELEASED; urgency=medium
+
+  * fix: The four corners can't be dragged properly in full-screen mode (Bug-310813)
+  * feat: add Apps winthin folder are dragged across pages. (Bug-288691)
+  * fix: Clicking tab multiple times to switch focus appear to switch back and forth (Bug-315227)
+  * fix: Uninstalling app in fullscreen doesn't close launcher (Bug-315255)
+  * fix: Add quotation marks to the app name in the uninstall dialog (Bug-315259)
+  * Update translations from Transifex
+
+-- Wu Jiangyu <wujiangyu@uniontech.com>  Fri, 29 May 2025 08:36:000 +0800
+
 dde-launchpad (1.99.12) UNRELEASED; urgency=medium
 
   * fix: clicking the left and right keys no response in fullscreen.


### PR DESCRIPTION
fix: The four corners can't be dragged properly in full-screen mode (Bug-310813) 
feat: add Apps winthin folder are dragged across pages. (Bug-288691) 
fix: Clicking tab multiple times to switch focus appear to switch back and forth (Bug-315227) 
fix: Uninstalling app in fullscreen doesn't close launcher (Bug-315255) 
fix: Add quotation marks to the app name in the uninstall dialog (Bug-315259) 
Update translations from Transifex

Log: release dde-launchpad 1.99.13

## Summary by Sourcery

Prepare and document the release of dde-launchpad version 1.99.13.

Build:
- Update the Debian changelog for version 1.99.13, incorporating recent bug fixes, a new feature, and translation updates.
- Update translations from Transifex.
- Add quotation marks to app names in the uninstall dialog for better readability.
- Correct an issue preventing proper dragging of corners in full-screen mode.
- Ensure the launcher closes correctly after an app is uninstalled in full-screen mode.
- Resolve erratic focus switching when clicking tabs multiple times.