### PR TITLE
fix: cancel hovered state after move mouse in the categorized display.

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -165,7 +165,7 @@ FocusScope {
                                         anchors.rightMargin: 10
                                         anchors.top: parent.top
                                         anchors.bottom: parent.bottom
-                                        visible: menuItem.down || menuItem.highlighted
+                                        visible: menuItem.down || menuItem.hovered
                                         outsideBorderColor: null
                                         insideBorderColor: null
                                         radius: 6


### PR DESCRIPTION
as title.

pms-bug-271375

## Summary by Sourcery

Bug Fixes:
- Corrected the hover state rendering in the app list view to properly show background highlight