### PR TITLE
fix: add x-dde-dock-dnd-source for dde-dock

### DIFF
--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -49,6 +49,7 @@ QtObject {
         }
         if (!DesktopIntegration.appIsDummyPackage(desktopId)) {
             mime["text/x-dde-dock-dnd-appid"] = desktopId
+            mime["text/x-dde-dock-dnd-source"] = "launcher"
         }
         return mime
     }


### PR DESCRIPTION
when drag app from laucher to dock can be classified.

Log: updateDragSource

## Summary by Sourcery

Enhancements:
- Extend MIME type metadata to include the drag source when moving apps between launcher and dock