### PR TITLE
fix: Dragging applications in application folder cannot create a new page

### DIFF
--- a/src/models/itemarrangementproxymodel.h
+++ b/src/models/itemarrangementproxymodel.h
@@ -58,7 +58,7 @@ public:
     Q_INVOKABLE void updateFolderName(int folderId, const QString & name);
     Q_INVOKABLE void bringToFront(const QString & id);
     Q_INVOKABLE void commitDndOperation(const QString & dragId, const QString & dropId, const DndOperation op, int pageHint = -1);
-    Q_INVOKABLE int creatEmptyPage() const;
+    Q_INVOKABLE int creatEmptyPage(int folderId = 0) const;
     Q_INVOKABLE void removeEmptyPage() const;
 
     ItemsPage *itemsPage() { return m_topLevel; }
@@ -70,6 +70,7 @@ public:
 
 signals:
     void topLevelPageCountChanged();
+    void folderPageCountChanged(int folderId);
 
 private:
     explicit ItemArrangementProxyModel(QObject *parent = nullptr);


### PR DESCRIPTION
as title.

pms-bug-288839

## Summary by Sourcery

Enable dynamic creation of new pages within application folders by dragging items to the folder’s edge and update the page indicator when the folder’s page count changes.

Bug Fixes:
- Allow dragging applications to the right padding area of an application folder to create a new page instead of blocking the action.

Enhancements:
- Introduce a `createdEmptyPage` flag in QML to prevent duplicate page creation during drag operations.
- Extend `ItemArrangementProxyModel::creatEmptyPage` to accept a folder ID and handle folder-specific page creation.
- Emit `folderPageCountChanged` from the proxy model and update the QML `gridViews` repeater model when a folder’s page count changes.
- Reset the `createdEmptyPage` flag after completing a drop operation.