### PR TITLE
chore: release dde-launchpad 1.99.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-launchpad (1.99.14) UNRELEASED; urgency=medium
+
+  * fix: Dragging applications in application folder cannot create a new page (Bug-288839)
+  * fix: add x-dde-dock-dnd-source for dde-dock.
+  * fix: cancel hovered state after move mouse in the categorized display. (Bug-271375)
+
+-- Wu Jiangyu <wujiangyu@uniontech.com>  Tue, 13 May 2025 17:17:000 +0800
+
 dde-launchpad (1.99.13) UNRELEASED; urgency=medium
 
   * fix: The four corners can't be dragged properly in full-screen mode (Bug-310813)


### PR DESCRIPTION
fix: Dragging applications in application folder cannot create a new page (Bug-288839)
fix: add x-dde-dock-dnd-source for dde-dock.
fix: cancel hovered state after move mouse in the categorized display. (Bug-271375)

Log: release dde-launchpad 1.99.14

## Summary by Sourcery

Release dde-launchpad 1.99.14 with several bug fixes and a version bump.

Bug Fixes:
- Allow dragging applications in the application folder to create a new page.
- Add x-dde-dock-dnd-source support to dde-dock.
- Reset hovered state when moving the mouse in the categorized display.

Chores:
- Bump dde-launchpad version to 1.99.14.