### PR TITLE
Revert "feat: Add fuzzy search support for applications"

### DIFF
--- a/src/models/searchfilterproxymodel.cpp
+++ b/src/models/searchfilterproxymodel.cpp
@@ -18,29 +18,6 @@ SearchFilterProxyModel::SearchFilterProxyModel(QObject *parent)
     sort(0, Qt::DescendingOrder);
 }
 
-bool SearchFilterProxyModel::fuzzyMatch(const QString &modelData, const QString &pattern) const
-{
-    if (modelData.contains(pattern, Qt::CaseInsensitive)) {
-        return true;
-    }
-    QString processedText = modelData.toLower().simplified();
-    int textLen = processedText.length();
-    int patternLen = pattern.length();
-    std::vector<std::vector<int>> dp(textLen + 1, std::vector<int>(patternLen + 1, 0));
-    for (int i = 1; i <= textLen; i++) {
-        for (int j = 1; j <= patternLen; j++) {
-            if (processedText[i - 1] == pattern[j - 1]) {
-                dp[i][j] = dp[i - 1][j - 1] + 1;
-            } else {
-                dp[i][j] = std::max(dp[i - 1][j], dp[i][j - 1]);
-            }
-        }
-    }
-
-    float matchScore = static_cast<float>(dp[textLen][patternLen]) / patternLen;
-    return matchScore >= m_fuzzyThreshold;
-}
-
 bool SearchFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
 {
     QModelIndex modelIndex = this->sourceModel()->index(sourceRow, 0, sourceParent);
@@ -49,8 +26,11 @@ bool SearchFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &
     const QString & displayName = modelIndex.data(Qt::DisplayRole).toString();
     const QString & name = modelIndex.data(AppsModel::NameRole).toString();
     const QString & transliterated = modelIndex.data(AppsModel::AllTransliteratedRole).toString();
+    const QString & jianpin = Dtk::Core::firstLetters(displayName).join(',');
 
-    QString pattern = searchPattern.pattern().toLower().remove(" ");
+    auto nameCopy = name;
+    nameCopy = nameCopy.toLower();
+    nameCopy.replace(" ", "");
 
-    return fuzzyMatch(displayName, pattern) || fuzzyMatch(name, pattern) || fuzzyMatch(transliterated, pattern);
+    return displayName.contains(searchPattern) || nameCopy.contains(searchPattern) || transliterated.contains(searchPattern) || jianpin.contains(searchPattern);
 }

--- a/src/models/searchfilterproxymodel.h
+++ b/src/models/searchfilterproxymodel.h
@@ -31,6 +31,4 @@ protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
 private:
     explicit SearchFilterProxyModel(QObject *parent = nullptr);
-    bool fuzzyMatch(const QString &modelData, const QString &pattern) const;
-    float m_fuzzyThreshold = 0.8f; 
 };


### PR DESCRIPTION
This reverts commit 8e2bca74581051ce1e35c4b0414467b255d5e69e.

## Summary by Sourcery

Revert fuzzy search support and simplify search filter logic to use direct substring matching across multiple name representations.

Enhancements:
- Simplify filterAcceptsRow to use direct substring checks on displayName, normalized name, transliterated text, and initial letters.
- Add jianpin matching via Dtk::Core::firstLetters.

Chores:
- Remove fuzzyMatch method and fuzzy threshold configuration.