### PR TITLE
fix: search app when use blank can not find app.

### DIFF
--- a/src/models/searchfilterproxymodel.cpp
+++ b/src/models/searchfilterproxymodel.cpp
@@ -32,5 +32,7 @@ bool SearchFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &
     nameCopy = nameCopy.toLower();
     nameCopy.replace(" ", "");
 
-    return displayName.contains(searchPattern) || nameCopy.contains(searchPattern) || transliterated.contains(searchPattern) || jianpin.contains(searchPattern);
+    QString searchPatternDelBlank = searchPattern.pattern().toLower().remove(" ");
+
+    return displayName.contains(searchPatternDelBlank) || nameCopy.contains(searchPatternDelBlank) || transliterated.contains(searchPatternDelBlank) || jianpin.contains(searchPatternDelBlank);
 }


### PR DESCRIPTION
as title.

PMS-BUG-288459

## Summary by Sourcery

Bug Fixes:
- Trim spaces from the search pattern before performing name matching to fix blank-containing searches