### PR TITLE
fix: when only one page, hide indicator.

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -266,7 +266,7 @@ InputEventItem {
 
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.verticalCenter: parent.verticalCenter
-                        visible: listviewPage.visible
+                        visible: count !== 1
                         count: searchResultGridViewContainer.visible ? 1 : listviewPage.count
                         currentIndex: searchResultGridViewContainer.visible ? 1 : listviewPage.currentIndex
                         interactive: true


### PR DESCRIPTION
as title.

PMS-BUG-289095

## Summary by Sourcery

Bug Fixes:
- Hide page indicator when only one page is present in FullscreenFrame.qml.