### PR TITLE
fix: Dock can overlapping right-click menu

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -19,7 +19,9 @@ Loader {
     property bool hideFavoriteMenu
     property bool hideMoveToTopMenu
     property bool hideDisplayScalingMenu
-
+    readonly property bool isFullscreen: LauncherController.currentFrame === "FullscreenFrame"
+    readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
+    readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
     signal closed()
 
     Component {
@@ -28,6 +30,10 @@ Loader {
         Menu {
             id: contextMenu
 
+            topMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.UpArrow ? dockSpacing : 0
+            bottomMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.DownArrow ? dockSpacing : 0
+            leftMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.LeftArrow ? dockSpacing : 0
+            rightMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.RightArrow ? dockSpacing : 0
             modal: true
 
             MenuItem {

--- a/qml/DummyAppItemMenu.qml
+++ b/qml/DummyAppItemMenu.qml
@@ -13,7 +13,9 @@ Loader {
     id: root
 
     property string desktopId
-
+    readonly property bool isFullscreen: LauncherController.currentFrame === "FullscreenFrame"
+    readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
+    readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
     signal closed()
 
     Component {
@@ -21,6 +23,10 @@ Loader {
 
         Menu {
             id: contextMenu
+            topMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.UpArrow ? dockSpacing : 0
+            bottomMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.DownArrow ? dockSpacing : 0
+            leftMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.LeftArrow ? dockSpacing : 0
+            rightMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.RightArrow ? dockSpacing : 0
             modal: true
 
             MenuItem {


### PR DESCRIPTION
PR-455 and PR-454.
Set menu margin according to dock location

PMS-BUG-316719

## Summary by Sourcery

Bug Fixes:
- Add dynamic margins to context menus in both AppItemMenu and DummyAppItemMenu to account for dock position and prevent overlap in fullscreen mode.