### PR TITLE
fix: when debug, delete the warning logs.

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -200,7 +200,7 @@ InputEventItem {
                         }
                     }
                     // TODO: this might not be the correct way to handle wheel
-                    onWheel: {
+                    onWheel: function(wheel) {
                         if (flipPageDelay.running) return
                         let xDelta = wheel.angleDelta.x / 8
                         let yDelta = wheel.angleDelta.y / 8
@@ -346,7 +346,7 @@ InputEventItem {
                         MouseArea {
                             anchors.fill: parent
                             acceptedButtons: Qt.RightButton | Qt.LeftButton
-                            onClicked: {
+                            onClicked: function(mouse) {
                                 // FIXME: prevent the bug:https://bugreports.qt.io/browse/QTBUG-125139;
                                 if (mouse.button === Qt.RightButton) {
                                     mouse.accepted = false;
@@ -672,7 +672,7 @@ InputEventItem {
         }
 
         Keys.forwardTo: [searchEdit]
-        Keys.onPressed: {
+        Keys.onPressed: function(event) {
             if (baseLayer.focus === true) {
                 // the SearchEdit will catch the key event first, and events that it won't accept will then got here
                 switch (event.key) {

--- a/qml/windowed/AppList.qml
+++ b/qml/windowed/AppList.qml
@@ -26,7 +26,9 @@ ColumnLayout {
     }
 
     function resetViewState() {
-        loader.item.resetViewState()
+        if (CategorizedSortProxyModel.categoryType !== CategorizedSortProxyModel.FreeCategory) {
+            loader.item.resetViewState()
+        }
     }
 
     function switchToFreeSort(freeSort) {

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -255,7 +255,7 @@ FocusScope {
                 Drag.dragType: Drag.Automatic
                 Drag.mimeData: Helper.generateDragMimeData(model.desktopId, true)
                 Drag.hotSpot.y: height / 2
-                Drag.hotSpot.x: Drag.hotSpot.y
+                Drag.hotSpot.x: width / 2
 
                 states: State {
                     name: "dragged";


### PR DESCRIPTION
as title

Log: delete warning logs

## Summary by Sourcery

Refine QML event handlers and view behaviors to improve event argument handling, conditional view resets, and drag positioning.

Bug Fixes:
- Prevent resetViewState from running when in FreeCategory to avoid unintended resets
- Center the drag hotspot horizontally by using width/2 for Drag.hotSpot.x

Enhancements:
- Convert onWheel, onClicked, and Keys.onPressed handlers to explicit function syntax for proper event argument handling