### PR TITLE
feat: add Support for acronym matching and others.

### DIFF
--- a/src/models/searchfilterproxymodel.cpp
+++ b/src/models/searchfilterproxymodel.cpp
@@ -34,5 +34,91 @@ bool SearchFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &
 
     QString searchPatternDelBlank = searchPattern.pattern().toLower().remove(" ");
 
-    return displayName.contains(searchPatternDelBlank) || nameCopy.contains(searchPatternDelBlank) || transliterated.contains(searchPatternDelBlank) || jianpin.contains(searchPatternDelBlank);
+    // Get first letters of each word in displayName
+    QStringList words = displayName.split(" ", Qt::SkipEmptyParts);
+    QString nameFirstLetters;
+    for (const QString &word : words) {
+        if (!word.isEmpty()) {
+            QChar firstChar = word[0];
+            if (firstChar.isLetter()) {
+                nameFirstLetters += firstChar.toLower();
+            }
+        }
+    }
+
+    // Check for number or English prefix matches only
+    QRegularExpression searchNumberCheck("\\d+$");
+    QRegularExpression searchEnglishCheck("^[a-zA-Z\\s]+$");
+    bool isNumberSearch = searchNumberCheck.match(searchPatternDelBlank).hasMatch();
+    bool isEnglishSearch = searchEnglishCheck.match(searchPattern.pattern()).hasMatch();
+
+    if (isNumberSearch || isEnglishSearch) {
+        bool hasMatch = false;
+
+        // Handle number prefix matching
+        if (isNumberSearch) {
+            QRegularExpression numberRegex("\\d+");
+            QRegularExpressionMatchIterator matches = numberRegex.globalMatch(displayName);
+
+            while (matches.hasNext()) {
+                QRegularExpressionMatch match = matches.next();
+                QString numberInDisplayName = match.captured(0);
+                hasMatch = true;
+                if (numberInDisplayName.startsWith(searchPatternDelBlank)) {
+                    return true;
+                }
+            }
+        }
+
+        // Handle English prefix matching
+        if (isEnglishSearch) {
+            // Remove spaces and convert to lowercase for comparison
+            QString displayNameLower = displayName.toLower().remove(" ");
+
+            // Check prefix matching for various name formats
+            if (displayNameLower.startsWith(searchPatternDelBlank) ||
+                nameCopy.startsWith(searchPatternDelBlank) ||
+                transliterated.startsWith(searchPatternDelBlank) ||
+                jianpin.startsWith(searchPatternDelBlank) ||
+                nameFirstLetters.startsWith(searchPatternDelBlank)) {
+                return true;
+            }
+
+            // Also check if search pattern matches the prefix of any word in displayName
+            for (const QString &word : words) {
+                if (word.toLower().startsWith(searchPatternDelBlank)) {
+                    return true;
+                }
+            }
+
+            // Also check if search pattern matches the prefix of any word in name
+            QStringList nameWords = name.split(" ", Qt::SkipEmptyParts);
+            for (const QString &word : nameWords) {
+                if (word.toLower().startsWith(searchPatternDelBlank)) {
+                    return true;
+                }
+            }
+
+            // Also check if search pattern matches the prefix of any word in transliterated
+            QStringList transliteratedWords = transliterated.split(" ", Qt::SkipEmptyParts);
+            for (const QString &word : transliteratedWords) {
+                if (word.toLower().startsWith(searchPatternDelBlank)) {
+                    return true;
+                }
+            }
+
+            hasMatch = true; // English content was found
+        }
+
+        // If we had matches but none were prefix matches, return false
+        if (hasMatch) {
+            return false;
+        }
+    }
+
+    return displayName.contains(searchPatternDelBlank) ||
+           nameCopy.contains(searchPatternDelBlank) ||
+           transliterated.contains(searchPatternDelBlank) ||
+           jianpin.contains(searchPatternDelBlank) ||
+           nameFirstLetters.contains(searchPatternDelBlank);
 }


### PR DESCRIPTION
add Support for acronym matching,
add Intermediate matching is not supported for lowercase letters.

Log:

## Summary by Sourcery

Refine the search filter logic to support acronym-based lookups, enforce prefix matching for lowercase names, and handle numeric-only display names separately while retaining existing matching behavior for other cases.

New Features:
- Add acronym matching by extracting initials of displayName words

Enhancements:
- Restrict substring matching to prefix-only for lowercase-only names
- Special-case numeric names to only match leading digits
- Preserve legacy substring matching for mixed-case or non-English display names