### PR TITLE
fix: when drag app to another app from folder,add animation and auto-move with folders.

### DIFF
--- a/qml/GridViewContainer.qml
+++ b/qml/GridViewContainer.qml
@@ -68,12 +68,19 @@ FocusScope {
         Rectangle {
             anchors.centerIn: parent
             width: {
-                if (root.objectName === "folderGridViewContainer")
-                    return model.rowCount() > root.columns - 1 ? item.cellWidth * root.columns : model.rowCount() * item.cellWidth
-                else
+                if (root.objectName === "folderGridViewContainer") {
+                    return item.cellWidth * root.columns + root.paddingColumns * Math.max(0, root.columns - 1) + root.paddingColumns
+                } else {
                     return item.cellWidth * root.columns
+                }
             }
-            height: rows == 0 ? parent.height : (item.cellHeight * root.rows)
+            height: {
+                if (root.objectName === "folderGridViewContainer") {
+                    return item.cellHeight * root.rows + root.paddingColumns * Math.max(0, root.rows - 1)
+                } else {
+                    return root.rows == 0 ? parent.height : (item.cellHeight * root.rows)
+                }
+            }
             color: "transparent"
 
             GridView {

--- a/qml/windowed/GridViewContainer.qml
+++ b/qml/windowed/GridViewContainer.qml
@@ -30,6 +30,7 @@ FocusScope {
     property int paddingRows: Helper.frequentlyUsed.cellPaddingRows
     property real cellHeight: 82
     property real cellWidth: 80
+    property Transition itemMove
 
     readonly property alias currentItem: gridView.currentItem
     readonly property alias gridViewWidth: gridView.width
@@ -83,6 +84,10 @@ FocusScope {
             }
             cellHeight: root.cellHeight + paddingRows
             cellWidth: root.cellWidth + paddingColumns
+
+            displaced: root.itemMove
+            move: root.itemMove
+            moveDisplaced: root.itemMove
 
             highlight: Item {
                 FocusBoxBorder {


### PR DESCRIPTION
as title.

PMS-BUG-288847

## Summary by Sourcery

Improve folder grid drag-and-drop by adding sorted models, consistent move animations, and timed edge-triggered auto-move previews

New Features:
- Automatically preview and execute insert moves when dragging an app near the edges of a folder after a short delay

Bug Fixes:
- Restore smooth reposition animations for items moved between apps within folders

Enhancements:
- Wrap folder items in a SortProxyModel with filterOnlyMode to maintain consistent ordering
- Extract and apply a reusable itemMove Transition with eased animation and shorter duration via GridViewContainer