### PR TITLE
chore: release dde-launchpad 1.99.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-launchpad (1.99.17) unstable; urgency=medium
+
+  * feat: add focus with AlphabetCategory when change to another word.
+  * feat: Added left and right button switching in full-screen mode.
+  * fix: when drag app to another app from folder,add animation and
+    auto-move with folders.
+  * fix: app will automatically fill in  from the first page of folder
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 12 Jun 2025 19:14:36 +0800
+
 dde-launchpad (1.99.16) UNRELEASED; urgency=medium
 
   * fix: when only one page, hide indicator. 


### PR DESCRIPTION
release dde-launchpad 1.99.17

## Summary by Sourcery

Update Debian changelog to release dde-launchpad version 1.99.17

Chores:
- Bump dde-launchpad version to 1.99.17 in debian/changelog
- Update release date and changelog entries for new version