### PR TITLE
fix: when drag app for move to anthoer area,add speed with change pos…

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -390,7 +390,7 @@ Popup {
                                         
                                         Timer {
                                             id: folderDragApplyTimer
-                                            interval: 500
+                                            interval: 400
                                             property string dragId: ""
                                             property real currentDropX: 0
                                             onTriggered: function() {

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -450,7 +450,7 @@ InputEventItem {
 
                                 Timer {
                                     id: dndDropEnterTimer
-                                    interval: 500
+                                    interval: 400
                                     property string dragId: ""
                                     onTriggered: function() {
                                         if (dragId === "") return


### PR DESCRIPTION
…ition.

as title.

PMS-BUG-286949

## Summary by Sourcery

Improve drag-and-drop responsiveness by reducing timer intervals for applying folder drags and handling drop-enter events.

Bug Fixes:
- Reduce folderDragApplyTimer interval from 500ms to 400ms
- Reduce dndDropEnterTimer interval from 500ms to 400ms