### PR TITLE
chore: release dde-launchpad 2.0.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-launchpad (2.0.0) unstable; urgency=medium
+
+  * i18n: Updates for project Deepin Desktop Environment (#581)
+  * fix: when drag app for move to anthoer area,add speed with change position.
+  * fix: when search item, modify select color.
+
+-- yeshanshan <yeshanshan@deepin.org>  Thu, 18 Jun 2025 19:22:00 +0800
+
 dde-launchpad (1.99.17) UNRELEASED; urgency=medium
 
   * fix: app will automatically fill in from the first page of folder


### PR DESCRIPTION
as title.

## Summary by Sourcery

Build:
- Update Debian packaging changelog for version 2.0.0