### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-launchpad (2.0.1) unstable; urgency=medium
+
+  * feat: add search for Uppercase and modify deepin-XXX logic.
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Mon, 23 Jun 2025 16:41:52 +0800
+
 dde-launchpad (2.0.0) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Desktop Environment (#581)


### PR DESCRIPTION
update changelog to 2.0.1

## Summary by Sourcery

Chores:
- Bump version to 2.0.1 and update Debian changelog