### PR TITLE
chore: avoid show confirm uninstall dialog when have preuninstall hook

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -197,6 +197,20 @@ void DesktopIntegration::setAutoStart(const QString &desktopId, bool on)
     return AppMgr::setAutoStart(desktopId, on);
 }
 
+bool DesktopIntegration::shouldSkipConfirmUninstallDialog(const QString &desktopId) const
+{
+    bool result = false;
+    const QString & fullPath = AppInfo::fullPathByDesktopId(desktopId);
+    if (fullPath.isEmpty()) return result;
+
+    DDesktopEntry entry(fullPath);
+    if (!entry.stringValue("X-Deepin-PreUninstall").isEmpty()) {
+        result = true;
+    }
+
+    return result;
+}
+
 void DesktopIntegration::uninstallApp(const QString &desktopId)
 {
     const QString & fullPath = AppInfo::fullPathByDesktopId(desktopId);

--- a/desktopintegration.h
+++ b/desktopintegration.h
@@ -64,6 +64,7 @@ public:
     Q_INVOKABLE void removeFromDesktop(const QString & desktopId);
     Q_INVOKABLE bool isAutoStart(const QString & desktopId) const;
     Q_INVOKABLE void setAutoStart(const QString & desktopId, bool on = true);
+    Q_INVOKABLE bool shouldSkipConfirmUninstallDialog(const QString & desktopId) const;
     Q_INVOKABLE void uninstallApp(const QString & desktopId);
     qreal opacity() const;
 

--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -132,16 +132,20 @@ Loader {
                 enabled: !root.desktopId.startsWith("internal/folders/") && !DesktopIntegration.appIsCompulsoryForDesktop(root.desktopId)
                 text: qsTr("Uninstall")
                 onTriggered: {
-                    if(LauncherController.currentFrame !== "FullscreenFrame"){
+                    if (LauncherController.currentFrame !== "FullscreenFrame") {
                         LauncherController.setAvoidHide(true)
                         LauncherController.visible = false
-                    }else{
+                    } else {
                         LauncherController.setAvoidHide(false) 
                     }
-                    confirmUninstallDlg.appName = root.display
-                    confirmUninstallDlg.appId = root.desktopId
-                    confirmUninstallDlg.icon = root.iconName
-                    confirmUninstallDlg.show()
+                    if (!DesktopIntegration.shouldSkipConfirmUninstallDialog(root.desktopId)) {
+                        confirmUninstallDlg.appName = root.display
+                        confirmUninstallDlg.appId = root.desktopId
+                        confirmUninstallDlg.icon = root.iconName
+                        confirmUninstallDlg.show()
+                    } else {
+                        DesktopIntegration.uninstallApp(root.desktopId)
+                    }
                 }
             }
 


### PR DESCRIPTION
存在卸载前钩子时,不显示卸载提示对话框,由卸载钩子来显示.

## Summary by Sourcery

Skip the uninstall confirmation dialog and invoke uninstallation directly when an application declares a pre-uninstall hook.

Enhancements:
- Introduce shouldSkipConfirmUninstallDialog in DesktopIntegration to detect X-Deepin-PreUninstall hooks.
- Update AppItemMenu.qml to conditionally bypass the confirmation dialog and call uninstallApp directly when the hook exists.