### PR TITLE
fix: add hardening compiler flags for Debian build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@ export QT_SELECT=5
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 # see ENVIRONMENT in dpkg-buildflags(1)
 # package maintainers to append CFLAGS


### PR DESCRIPTION
1. Added DEB_CFLAGS_MAINT_APPEND with -Wall for C compiler warnings
2. Added DEB_CXXFLAGS_MAINT_APPEND with -Wall for C++ compiler warnings
3. Added DEB_LDFLAGS_MAINT_APPEND with multiple security hardening flags:
   - --as-needed for linking only required libraries
   - -z,relro for read-only relocation sections
   - -z,now for immediate binding
   - -z,noexecstack for non-executable stacks
   - -E for exporting symbols
4. These changes improve security and catch potential issues during compilation

fix: 为 Debian 构建添加强化编译选项

1. 为 C 编译器添加 DEB_CFLAGS_MAINT_APPEND 包含 -Wall 警告选项
2. 为 C++ 编译器添加 DEB_CXXFLAGS_MAINT_APPEND 包含 -Wall 警告选项
3. 为链接器添加 DEB_LDFLAGS_MAINT_APPEND 包含多个安全强化选项：
   - --as-needed 仅链接需要的库
   - -z,relro 设置只读重定位段
   - -z,now 启用立即绑定
   - -z,noexecstack 禁用可执行栈
   - -E 导出符号
4. 这些变更提高了安全性并在编译时捕获潜在问题

## Summary by Sourcery

Add security hardening and warning flags to Debian packaging build rules

Build:
- Append -Wall to DEB_CFLAGS_MAINT_APPEND and DEB_CXXFLAGS_MAINT_APPEND for C/C++ compiler warnings
- Add DEB_LDFLAGS_MAINT_APPEND with security hardening flags (--as-needed, -z relro, -z now, -z noexecstack, -E)