### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-launchpad (2.0.2) unstable; urgency=medium
+
+  * fix: add hardening compiler flags for Debian build
+  * chore: avoid show confirm uninstall dialog when have preuninstall
+    hook
+  * i18n: Updates for project Deepin Desktop Environment (#588)
+  * fix: when fullscreen, click dock, launchpad will not close.
+  * i18n: Translate org.deepin.ds.dock.launcherapplet.ts in pt_BR (#584)
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Thu, 03 Jul 2025 19:59:52 +0800
+
 dde-launchpad (2.0.1) unstable; urgency=medium
 
   * feat: add search for Uppercase and modify deepin-XXX logic.


### PR DESCRIPTION
update changelog to 2.0.2

## Summary by Sourcery

Bump package version to 2.0.2 and update the Debian changelog accordingly

Documentation:
- Update Debian changelog for version 2.0.2

Chores:
- Bump version to 2.0.2