### PR TITLE
feat: add package name search configuration

### DIFF
--- a/src/models/org.deepin.ds.launchpad.json
+++ b/src/models/org.deepin.ds.launchpad.json
@@ -75,6 +75,17 @@
       "description[zh_CN]": "在窗口模式下排序应用列表的类别。0: 首字母分组排序，1: DDE 风格分类，2: 自由排序",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "searchByDesktopId": {
+      "value": false,
+      "serial": 0,
+      "flags": [],
+      "name": "searchByDesktopId",
+      "name[zh_CN]": "按桌面条目 ID 搜索",
+      "description": "Whether to allow the search for Desktop ID during the search.",
+      "description[zh_CN]": "在搜索时候是否允许搜索Desktop ID。",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }

--- a/src/models/searchfilterproxymodel.h
+++ b/src/models/searchfilterproxymodel.h
@@ -7,6 +7,10 @@
 #include <QtQml/qqml.h>
 #include <QSortFilterProxyModel>
 
+namespace Dtk::Core {
+class DConfig;
+}
+
 class SearchFilterProxyModel : public QSortFilterProxyModel
 {
     Q_OBJECT
@@ -35,4 +39,7 @@ private:
     explicit SearchFilterProxyModel(QObject *parent = nullptr);
 
     int calculateWeight(const QModelIndex &modelIndex) const;
+
+    Dtk::Core::DConfig *m_dconfig;
+    bool m_searchPackageEnabled;
 };


### PR DESCRIPTION
1. Added new DConfig setting "searchPackage" to control package name search functionality
2. Implemented package name search in SearchFilterProxyModel when enabled
3. Added DConfig monitoring to dynamically update search behavior when setting changes
4. Package name search includes exact match, starts with, and contains matching
5. Added desktopId comparison in calculateWeight method for package name matching

The changes allow users to enable/disable package name searching through DConfig, providing more flexible search options. This is particularly useful for technical users who may want to search applications by their package names.

feat: 添加包名搜索配置功能

1. 新增 DConfig 设置项 "searchPackage" 用于控制包名搜索功能
2. 在 SearchFilterProxyModel 中实现包名搜索功能（当启用时）
3. 添加 DConfig 监听以动态更新搜索行为
4. 包名搜索支持精确匹配、开头匹配和包含匹配
5. 在 calculateWeight 方法中添加 desktopId 比较用于包名匹配

这些改动允许用户通过 DConfig 启用/禁用包名搜索功能，提供更灵活的搜索选
项。对于技术用户来说特别有用，他们可能希望通过包名来搜索应用程序。

## Summary by Sourcery

Enable users to search applications by package name by adding a DConfig-controlled switch and matching logic in SearchFilterProxyModel

New Features:
- Add DConfig setting `searchPackage` to toggle package name search
- Extend SearchFilterProxyModel to include desktopId-based matching (exact, prefix, substring) when enabled
- Monitor DConfig changes to dynamically update search behavior