### PR TITLE
fix: update new app indicator styling

### DIFF
--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -187,7 +187,7 @@ Control {
                 property bool singleRow: font.pixelSize > (isWindowedMode ? Helper.windowed.doubleRowMaxFontSize : Helper.fullscreen.doubleRowMaxFontSize)
                 property bool isNewlyInstalled: model.lastLaunchedTime === 0 && model.installedTime !== 0
                 id: iconItemLabel
-                text: isNewlyInstalled ? ("<font color='#6CA6FF' size='1'>●</font>&nbsp;&nbsp;" + root.text) : root.text
+                text: isNewlyInstalled ? ("<font color='#669DFF' size='1' style='text-shadow: 0 0 1px rgba(255,255,255,0.1)'>●</font>&nbsp;&nbsp;" + root.text) : root.text
                 textFormat: isNewlyInstalled ? Text.RichText : Text.PlainText
                 width: parent.width
                 leftPadding: 2

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -246,15 +246,18 @@ FocusScope {
                     z: 1
                 }
                 Rectangle {
-                    width: 8
-                    height: 8
-                    radius: 4
-                    color: "#6CA6FF"
+                    width: 10
+                    height: 10
+                    radius: 5
+                    color: ApplicationHelper.DarkType === ApplicationHelper.LightType ? "#1C0560" : "#669DFF"
+                    border.width: 1
+                    border.color: ApplicationHelper.DarkType === ApplicationHelper.LightType ?
+                                 Qt.rgba(0, 0, 0, 0.1) : Qt.rgba(1, 1, 1, 0.1)
                     visible: model.lastLaunchedTime === 0 && model.installedTime !== 0
                     anchors {
                         right: parent.right
                         verticalCenter: parent.verticalCenter
-                        rightMargin: 4
+                        leftMargin: 6
                     }
                     z: 1
                 }

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -266,15 +266,18 @@ Item {
                     rightMargin: 10
                 }
                 Rectangle {
-                    width: 8
-                    height: 8
-                    radius: 4
-                    color: "#6CA6FF"
+                    width: 10
+                    height: 10
+                    radius: 5
+                    color: ApplicationHelper.DarkType === ApplicationHelper.LightType ? "#1C0560" : "#669DFF"
+                    border.width: 1
+                    border.color: ApplicationHelper.DarkType === ApplicationHelper.LightType ?
+                                 Qt.rgba(0, 0, 0, 0.1) : Qt.rgba(1, 1, 1, 0.1)
                     visible: model.lastLaunchedTime === 0 && model.installedTime !== 0
                     anchors {
                         right: parent.right
                         verticalCenter: parent.verticalCenter
-                        rightMargin: 4
+                        leftMargin: 6
                     }
                     z: 1
                 }


### PR DESCRIPTION
1. Changed new app indicator color from #6CA6FF to #669DFF for better consistency
2. Added subtle text shadow to the indicator dot in IconItemDelegate
3. Increased indicator size from 8x8 to 10x10 with 5px radius for better visibility
4. Added border and different colors for light/dark modes
5. Adjusted margins and positioning of indicators

style: 更新新应用指示器样式

1. 将新应用指示器颜色从 #6CA6FF 改为 #669DFF 以提高一致性
2. 在 IconItemDelegate 中为指示点添加微妙的文字阴影
3. 将指示器大小从 8x8 增加到 10x10，半径5px以提高可见性
4. 为浅色/深色模式添加边框和不同颜色
5. 调整指示器的边距和位置

Pms: BUG-321763 BUG-320021

## Summary by Sourcery

Revise the new app indicator’s appearance by updating its size, color, border, shadow, and positioning across QML components.

Enhancements:
- Increase new app indicator size to 10×10 with a 5px radius for improved visibility
- Use conditional colors and add a 1px border for light/dark modes
- Add a subtle text shadow to the indicator dot in IconItemDelegate
- Adjust margins and reposition indicators in AppListView and FreeSortListView