### PR TITLE
fix: Launchpad crash

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -140,75 +140,10 @@ FocusScope {
                                 ddeCategoryMenu.existingSections = CategorizedSortProxyModel.DDECategorySections()
                                 listView.opacity = 0.1
                                 root.categoryMenu = ddeCategoryMenu
-                                ddeCategoryMenu.open()
+                                ddeCategoryMenu.popup(headingBtn, 0, 0)
                             }
                         }
 
-                        Menu {
-                            id: ddeCategoryMenu
-                            width: 150
-                            modal: true
-                            closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-
-                            property var existingSections: []
-                            Repeater {
-                                model: ddeCategoryMenu.existingSections
-                                delegate: MenuItem {
-                                    id: menuItem
-                                    text: getCategoryName(modelData)
-                                    textColor: DStyle.Style.menu.itemText
-                                    onTriggered: {
-                                        scrollToDDECategory(modelData)
-                                    }
-                                    contentItem: IconLabel {
-                                        alignment: Qt.AlignCenter
-                                        text: menuItem.text
-                                        color: parent.palette.windowText
-                                    }
-                                    background: BoxPanel {
-                                        anchors.left: parent.left
-                                        anchors.leftMargin: 10
-                                        anchors.right: parent.right
-                                        anchors.rightMargin: 10
-                                        anchors.top: parent.top
-                                        anchors.bottom: parent.bottom
-                                        visible: menuItem.down || menuItem.hovered
-                                        outsideBorderColor: null
-                                        insideBorderColor: null
-                                        radius: 6
-
-                                        property Palette background: Palette {
-                                            normal {
-                                                common: Qt.rgba(0, 0, 0, 0.1)
-                                                crystal: Qt.rgba(0, 0, 0, 0.1)
-                                            }
-                                            normalDark {
-                                                common: Qt.rgba(1, 1, 1, 0.1)
-                                                crystal: Qt.rgba(1, 1, 1, 0.1)
-                                            }
-                                            hovered {
-                                                common: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
-                                                crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
-                                            }
-                                        }
-                                        color1: background
-                                        color2: background
-                                    }
-                                }
-                            }
-
-                            onVisibleChanged: {
-                                if (!visible) {
-                                    listView.opacity = 1
-                                }
-                            }
-                            background: FloatingPanel {
-                                radius: DStyle.Style.menu.radius
-                                backgroundColor: ddeCategoryMenu.backgroundColor
-                                backgroundNoBlurColor: ddeCategoryMenu.backgroundNoBlurColor
-                                dropShadowColor: null
-                            }
-                        }
                     }
                 }
             }
@@ -341,6 +276,72 @@ FocusScope {
                     launchApp(desktopId)
                 }
             }
+        }
+    }
+
+    Menu {
+        id: ddeCategoryMenu
+        width: 150
+        modal: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+        property var existingSections: []
+        Repeater {
+            model: ddeCategoryMenu.existingSections
+            delegate: MenuItem {
+                id: menuItem
+                text: getCategoryName(modelData)
+                textColor: DStyle.Style.menu.itemText
+                onTriggered: {
+                    scrollToDDECategory(modelData)
+                }
+                contentItem: IconLabel {
+                    alignment: Qt.AlignCenter
+                    text: menuItem.text
+                    color: parent.palette.windowText
+                }
+                background: BoxPanel {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    anchors.right: parent.right
+                    anchors.rightMargin: 10
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    visible: menuItem.down || menuItem.hovered
+                    outsideBorderColor: null
+                    insideBorderColor: null
+                    radius: 6
+
+                    property Palette background: Palette {
+                        normal {
+                            common: Qt.rgba(0, 0, 0, 0.1)
+                            crystal: Qt.rgba(0, 0, 0, 0.1)
+                        }
+                        normalDark {
+                            common: Qt.rgba(1, 1, 1, 0.1)
+                            crystal: Qt.rgba(1, 1, 1, 0.1)
+                        }
+                        hovered {
+                            common: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
+                            crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
+                        }
+                    }
+                    color1: background
+                    color2: background
+                }
+            }
+        }
+
+        onVisibleChanged: {
+            if (!visible) {
+                listView.opacity = 1
+            }
+        }
+        background: FloatingPanel {
+            radius: DStyle.Style.menu.radius
+            backgroundColor: ddeCategoryMenu.backgroundColor
+            backgroundNoBlurColor: ddeCategoryMenu.backgroundNoBlurColor
+            dropShadowColor: null
         }
     }
 


### PR DESCRIPTION
Move ddeCategoryMenu to root level and use popup()

- Relocate ddeCategoryMenu from nested position to root level in AppListView.qml
- Replace open() with popup() for better positioning relative to headingBtn
- Remove redundant Menu implementation while maintaining functionality

This improves code organization and ensures proper menu positioning.

pms: BUG-321849

## Summary by Sourcery

Fix Launchpad crash by relocating the ddeCategoryMenu definition to the root level, replacing open() with popup() for accurate positioning relative to the heading button, and removing the redundant nested menu implementation.

Bug Fixes:
- Prevent Launchpad crash by moving ddeCategoryMenu out of a nested scope in AppListView.qml

Enhancements:
- Use popup() instead of open() to position the category menu correctly under the heading button