### PR TITLE
feat: call pre-uninstall hook from launchpad

### DIFF
--- a/src/ddeintegration/appwiz.cpp
+++ b/src/ddeintegration/appwiz.cpp
@@ -6,7 +6,12 @@
 
 #include "DaemonLauncher1.h"
 
+#include <QThreadPool>
+#include <DDesktopEntry>
+
 using DaemonLauncher1 = __DaemonLauncher1;
+
+DCORE_USE_NAMESPACE
 
 AppWiz::AppWiz(QObject *parent)
     : QObject(parent)
@@ -21,14 +26,66 @@ AppWiz::~AppWiz()
 
 }
 
-// TODO: remove this and the whole m_dbusDaemonLauncherIface thing once the legacy dde-launcher is gone.
+// TODO: remove this and the whole m_dbusDaemonLauncherIface thing once we have a modern "appwiz" service for uninstalling apps.
 void AppWiz::legacyRequestUninstall(const QString &desktopFileFullPath)
 {
     qDebug() << "uninstall" << desktopFileFullPath;
     qDebug() << m_dbusDaemonLauncherIface->lastError();
 
-    QDBusPendingReply rpy = m_dbusDaemonLauncherIface->RequestUninstall(desktopFileFullPath, false);
-    if (rpy.isError()) {
-        qDebug() << rpy.error();
-    }
+    QThreadPool::globalInstance()->start([desktopFileFullPath, this](){
+
+        DDesktopEntry desktopEntry(desktopFileFullPath);
+        if (desktopEntry.status() != DDesktopEntry::NoError) {
+            qDebug() << "Desktop file" << desktopFileFullPath << "is invalid.";
+            return;
+        }
+
+        if (!desktopEntry.stringValue("X-Deepin-PreUninstall").isEmpty()) {
+            QFileInfo desktopFileInfo(desktopFileFullPath);
+            bool writable = desktopFileInfo.isWritable();
+            if (writable) {
+                qDebug() << "Desktop file" << desktopFileFullPath << "is writable, it might be a user-level .desktop file, avoiding execute the PreUninstall command.";
+            } else {
+                const QString & preUninstallScript = desktopEntry.stringValue("X-Deepin-PreUninstall");
+                // The script is usually a shell script, we need to execute it and check the return code.
+                // We don't need pkexec, execute it directly.
+                // If error, we should print the stderr and return.
+                QStringList args = QProcess::splitCommand(preUninstallScript);
+                QProcess process;
+                if (args.size() < 1) {
+                    qDebug() << "Pre-uninstall script" << preUninstallScript << "is invalid, aborting uninstallation for" << desktopFileFullPath;
+                    return;
+                } else if (args.size() == 1) {
+                    process.start(args[0]);
+                } else {
+                    process.start(args[0], args.mid(1));
+                }
+                bool succ = process.waitForFinished(-1);
+                if (!succ || process.exitCode() != 0) {
+                    const int exitCode = process.exitCode();
+                    qDebug() << "Pre-uninstall script" << preUninstallScript << "exited with exit code:" << exitCode << process.error();
+                    switch (exitCode) {
+                    case 101:
+                        qDebug() << "Which means user canceled uninstallation for" << desktopFileFullPath;
+                        qDebug() << "Thus aborting the uninstallation.";
+                        return;
+                    case 103:
+                        qDebug() << "Which means there is a running instance of the pre-uninstall script for" << desktopFileFullPath;
+                        qDebug() << "Thus aborting the uninstallation.";
+                        return;
+                    default:
+                        qDebug() << "stderr:" << process.readAllStandardError();
+                        qDebug() << "stdout:" << process.readAllStandardOutput();
+                        qDebug() << "Will continue uninstallation for" << desktopFileFullPath;
+                    }
+                }
+                qDebug() << "Pre-uninstall script" << preUninstallScript << "succeeded.";
+            }
+        }
+    
+        QDBusPendingReply rpy = m_dbusDaemonLauncherIface->RequestUninstall(desktopFileFullPath, true);
+        if (rpy.isError()) {
+            qDebug() << rpy.error();
+        }
+    });
 }

--- a/src/ddeintegration/xml/org.deepin.dde.daemon.Launcher1.xml
+++ b/src/ddeintegration/xml/org.deepin.dde.daemon.Launcher1.xml
@@ -1,7 +1,7 @@
 <interface name="org.deepin.dde.daemon.Launcher1">
   <method name="RequestUninstall">
     <arg direction="in" type="s" name="desktop"/>
-    <arg direction="in" type="b" name="unused"/>
+    <arg direction="in" type="b" name="skipPreinstallHook"/>
   </method>
   <signal name="UninstallSuccess">
     <arg type="s" name="appID"/>


### PR DESCRIPTION
此功能的详细背景请参见:

- https://github.com/linuxdeepin/dde-application-wizard/pull/47

## Summary by Sourcery

Implement support for pre-uninstall hooks by reading and executing X-Deepin-PreUninstall scripts before invoking the uninstaller, while maintaining legacy D-Bus uninstall behavior on a background thread.

New Features:
- Execute X-Deepin-PreUninstall scripts before app uninstallation, aborting on user cancellation or running-instances codes
- Skip pre-uninstall hook execution for user-level (.desktop) entries

Enhancements:
- Offload legacy uninstall requests to a background thread pool
- Rename D-Bus RequestUninstall boolean argument to 'skipPreinstallHook' for clarity