### PR TITLE
fix: reset view position on category type change

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -361,6 +361,13 @@ FocusScope {
             }
         }
 
+        Connections {
+            target: CategorizedSortProxyModel
+            function onCategoryTypeChanged() {
+                listView.positionViewAtBeginning()
+            }
+        }
+        
         section.property: CategorizedSortProxyModel.sortRoleName // "transliterated" // "category"
         section.criteria: section.property === "transliterated" ? ViewSection.FirstCharacter : ViewSection.FullString
         section.delegate: sectionHeading

--- a/src/models/categorizedsortproxymodel.cpp
+++ b/src/models/categorizedsortproxymodel.cpp
@@ -15,7 +15,8 @@ DCORE_USE_NAMESPACE
 void CategorizedSortProxyModel::setCategoryType(CategoryType categoryType)
 {
     CategoryType oldCategoryType = this->categoryType();
-
+    
+    beginResetModel();
     isFreeSort = (categoryType == FreeCategory);
     switch (categoryType) {
     case Alphabetary:
@@ -31,10 +32,12 @@ void CategorizedSortProxyModel::setCategoryType(CategoryType categoryType)
     if (oldCategoryType != categoryType) {
         QScopedPointer<DConfig> config(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
         config->setValue("categoryType", categoryType);
-        emit categoryTypeChanged();
     }
 
     sort(0);
+    endResetModel();
+
+    emit categoryTypeChanged();
 }
 
 CategorizedSortProxyModel::CategoryType CategorizedSortProxyModel::categoryType() const


### PR DESCRIPTION
1. Added Connections in AppListView.qml to reset list position when category type changes
2. Modified CategorizedSortProxyModel.cpp to properly emit signals and reset model
3. Now emits categoryTypeChanged after model reset and sorting completes
4. Ensures consistent view behavior when switching between different category types

fix: 类别类型更改时重置视图位置

1. 在 AppListView.qml 中添加连接，当类别类型改变时重置列表位置
2. 修改 CategorizedSortProxyModel.cpp 以正确发出信号并重置模型
3. 现在在模型重置和排序完成后发出 categoryTypeChanged 信号
4. 确保在不同类别类型之间切换时视图行为一致

Pms: BUG-322771

## Summary by Sourcery

Reset list view position on category type changes and ensure consistent model updates

Bug Fixes:
- Reset AppListView position when the category type changes
- Emit categoryTypeChanged signal after the proxy model reset and sort

Enhancements:
- Wrap sorting in beginResetModel/endResetModel in CategorizedSortProxyModel