### PR TITLE
feat: Disable itemMoveTransition when switching to FullscreenFrame

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -410,6 +410,8 @@ InputEventItem {
                             }
                             activeGridViewFocusOnTab: listviewPage.ListView.isCurrentItem
                             itemMove: Transition {
+                                id: itemMoveTransition
+                                enabled: false
                                 NumberAnimation {
                                     properties: "x,y"
                                     duration: 200
@@ -512,6 +514,24 @@ InputEventItem {
                                 target: dropArea
                                 function onDropped() {
                                     gridViewContainer.checkPageSwitchState()
+                                }
+                            }
+                            Timer {
+                                id: delayedEnableItemMoveTimer
+                                interval: 100
+                                onTriggered: function() {
+                                    itemMoveTransition.enabled = true
+                                }
+                            }
+                            Connections {
+                                target: LauncherController
+                                function onCurrentFrameChanged() {
+                                    // Disable itemMoveTransition on launch for bug https://pms.uniontech.com/bug-view-270945.html
+                                    if (LauncherController.currentFrame === "WindowedFrame") {
+                                        itemMoveTransition.enabled = false
+                                    } else {
+                                        delayedEnableItemMoveTimer.restart()
+                                    }
                                 }
                             }
                             Component.onCompleted: {

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -19,6 +19,18 @@ Item {
     property Item keyTabTarget: listView
     property bool animationEnabled: false
 
+    Timer {
+        id: enableAnimationTimer
+        interval: 100
+        onTriggered: {
+            root.animationEnabled = true
+        }
+    }
+
+    Component.onCompleted: {
+        enableAnimationTimer.start()
+    }
+
     onFocusChanged: () => {
         listView.focus = true
     }
@@ -209,7 +221,6 @@ Item {
 
             onEntered: function(drag) {
                 listDelegateDragApplyTimer.startTimer(drag.getDataAsString("text/x-dde-launcher-dnd-desktopId"))   
-                root.animationEnabled = true
                 if (folderGridViewPopup.opened) {
                     folderGridViewPopup.close()
                 }
@@ -222,7 +233,6 @@ Item {
             }
 
             onDropped: function(drop) {
-                root.animationEnabled = false
                 listDelegateDragApplyTimer.stopTimer()
                 drop.accept()
                 let dragId = drop.getDataAsString("text/x-dde-launcher-dnd-desktopId")
@@ -333,7 +343,6 @@ Item {
                             showContextMenu(itemDelegate, model, {
                                 hideMoveToTopMenu: index === 0
                             })
-
                             baseLayer.focus = true
                         } else {
                             launchItem()


### PR DESCRIPTION
Log: Disable itemMoveTransition when switching to FullscreenFrame

Pms: BUG-322771

## Summary by Sourcery

Disable itemMoveTransition during frame changes to prevent unintended movement animations and dynamically manage its state based on LauncherController events

Bug Fixes:
- Disable itemMoveTransition when switching to FullscreenFrame to address BUG-322771

Enhancements:
- Add Timer and Connections to re-enable itemMoveTransition with a short delay after entering FullscreenFrame