### PR TITLE
fix: disable drag when menus or popups are visible

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -234,6 +234,8 @@ FocusScope {
                     target: parent
                     acceptedButtons: Qt.LeftButton
                     dragThreshold: 1
+                    // 当分类菜单打开时，禁用拖拽功能
+                    enabled: !(ddeCategoryMenu.visible || alphabetCategoryPopup.visible)
                     onActiveChanged: {
                         if (active) {
                             // We switch to use the `dndItem` to handle Drag event since that one will always exists.

--- a/qml/windowed/FrequentlyUsedView.qml
+++ b/qml/windowed/FrequentlyUsedView.qml
@@ -56,7 +56,8 @@ Control {
                 width: frequentlyUsedViewContainer.cellWidth
                 height: frequentlyUsedViewContainer.cellHeight
                 iconSource: iconName
-                dndEnabled: true
+                // 当文件夹打开时禁用拖拽功能
+                dndEnabled: !folderGridViewPopup.visible
                 Drag.mimeData: Helper.generateDragMimeData(model.desktopId, true)
                 onItemClicked: {
                     launchApp(desktopId)

--- a/qml/windowed/RecentlyInstalledView.qml
+++ b/qml/windowed/RecentlyInstalledView.qml
@@ -53,7 +53,8 @@ Control {
                 iconSource: iconName
                 width: recentlyInstalledViewContainer.cellWidth
                 height: recentlyInstalledViewContainer.cellHeight
-                dndEnabled: true
+                // 当文件夹打开时禁用拖拽功能
+                dndEnabled: !folderGridViewPopup.visible
                 Drag.mimeData: Helper.generateDragMimeData(model.desktopId, true)
                 onItemClicked: {
                     launchApp(desktopId)


### PR DESCRIPTION
1. Disabled drag functionality in AppListView when category menu or alphabet popup is visible
2. Disabled drag functionality in FrequentlyUsedView and RecentlyInstalledView when folder popup is visible
3. Prevents accidental drag operations while interacting with menus/ popups
4. Improves user experience by avoiding conflicting interactions

fix: 菜单或弹出窗口可见时禁用拖拽功能

1. 当分类菜单或字母弹出窗口可见时，禁用AppListView中的拖拽功能
2. 当文件夹弹出窗口可见时，禁用FrequentlyUsedView和RecentlyInstalledView 中的拖拽功能
3. 防止与菜单/弹出窗口交互时意外触发拖拽操作
4. 通过避免交互冲突提升用户体验

Pms: BUG-323887

## Summary by Sourcery

Prevent accidental drag operations while interacting with menus or popups by disabling drag functionality in app list and folder views when overlays are visible.

Bug Fixes:
- Disable drag in AppListView when category menu or alphabet popup is visible
- Disable drag in FrequentlyUsedView and RecentlyInstalledView when folder popup is visible