### PR TITLE
fix: update hover colors and add dark mode variant

### DIFF
--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -35,8 +35,12 @@ QtObject {
             crystal: Qt.rgba(1, 1, 1, 0.1)
         }
         hovered {
-            common: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
-            crystal: Qt.rgba(16.0 / 255, 16.0 / 255, 16.0 / 255, 0.1)
+            common: Qt.rgba(0, 0, 0, 0.1)
+            crystal: Qt.rgba(0, 0, 0, 0.1)
+        }
+        hoveredDark {
+            common: Qt.rgba(1, 1, 1, 0.1)
+            crystal: Qt.rgba(1, 1, 1, 0.1)
         }
     }
 


### PR DESCRIPTION
1. Changed hovered colors from rgba(16,16,16,0.1) to rgba(0,0,0,0.1) for better consistency
2. Added new hoveredDark state with white hover colors for dark mode support
3. Simplified color values by using 0 instead of 16/255 calculations
4. Maintained same alpha transparency level (0.1) throughout changes

fix: 更新悬停颜色并添加深色模式变体

1. 将悬停颜色从 rgba(16,16,16,0.1) 改为 rgba(0,0,0,0.1) 以提高一致性
2. 新增 hoveredDark 状态，包含白色悬停颜色以支持深色模式
3. 通过使用 0 代替 16/255 计算简化了颜色值
4. 保持相同的透明度水平 (0.1) 贯穿所有更改

Pms: BUG-320207