### PR TITLE
fix: optimize drag and drop indicator behavior

### DIFF
--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -130,11 +130,10 @@ Item {
 
             property bool showDropIndicator: false
             property int op: 0 // DndPrepend = -1,DndJoin = 0, DndAppend = 1
-            readonly property int indicatorDefaultHeight: 1
 
             Timer {
                 id: listDelegateDragApplyTimer
-                interval: 500
+                interval: 300
                 repeat: true
                 running: false
                 property string dragId: ""
@@ -170,22 +169,16 @@ Item {
             function dropPositionCheck(mouseY, isDraggingFolder) {
                 let sideOpPadding = height / 3
                 if (mouseY < sideOpPadding) {
-                    dropIndicator.y = 0
-                    dropIndicator.height = indicatorDefaultHeight
                     op = -1
                 } else if (mouseY > (height - sideOpPadding)) {
-                    dropIndicator.y = itemDelegate.height
-                    dropIndicator.height = indicatorDefaultHeight
                     op = 1
                 } else {
                     if (isDraggingFolder) {
-                        dropIndicator.height = indicatorDefaultHeight
                         showDropIndicator = false
                     } else {
-                        dropIndicator.y = 0
-                        dropIndicator.height = itemDelegate.height
+                        // 保留hover状态，但不显示分割线
+                        showDropIndicator = true
                     }
-
                     op = 0
                 }
             }
@@ -214,7 +207,6 @@ Item {
                     isDraggingFolder = true
                 }
 
-                showDropIndicator = true
                 scrollViewWhenNeeded(drag.y)
                 dropPositionCheck(drag.y, isDraggingFolder)
             }
@@ -243,11 +235,11 @@ Item {
 
             Rectangle {
                 id: dropIndicator
-                x : 10
+                x: 10
                 width: bg.width
-                height: indicatorDefaultHeight
+                height: itemDelegate.height
                 visible: showDropIndicator
-                radius: height > indicatorDefaultHeight ? 8 : 1
+                radius: 8
 
                 property Palette background: Helper.itemBackground
                 color: dropIndicator.ColorSelector.background


### PR DESCRIPTION
1. Reduced drag apply timer interval from 500ms to 300ms for better responsiveness
2. Simplified drop position check logic by removing redundant indicator position updates
3. Changed indicator to always show full item height with rounded corners
4. Improved visual feedback by maintaining hover state without showing divider line
5. Fixed indicator styling to be consistent regardless of operation type

fix: 优化拖拽指示器行为

1. 将拖拽应用计时器间隔从500ms减少到300ms以提高响应速度
2. 简化拖放位置检查逻辑，移除冗余的指示器位置更新
3. 修改指示器始终显示完整项目高度并带有圆角
4. 通过保持悬停状态而不显示分割线来改善视觉反馈
5. 修复指示器样式使其在不同操作类型下保持一致

Pms: BUG-320203

## Summary by Sourcery

Improve drag-and-drop indicator responsiveness and consistency by reducing timer interval, streamlining position checks, and updating visual styling to always display full-height, rounded indicators with refined hover feedback.

Enhancements:
- Reduce drag apply timer interval from 500ms to 300ms for faster responsiveness
- Simplify drop position check logic by removing redundant indicator position updates
- Always render the drop indicator at full item height with rounded corners
- Maintain hover state feedback without showing the divider line
- Standardize drop indicator styling across all drag operations