### PR TITLE
fix: improve drop indicator implementation in FreeSortListView

### DIFF
--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -233,16 +233,17 @@ Item {
                 listViewDragScroller.stopScroll()
             }
 
-            Rectangle {
+            Control {
                 id: dropIndicator
                 x: 10
-                width: bg.width
-                height: itemDelegate.height
+                property Palette backgroundPalette: Helper.itemBackground
                 visible: showDropIndicator
-                radius: 8
-
-                property Palette background: Helper.itemBackground
-                color: dropIndicator.ColorSelector.background
+                Rectangle {
+                    width: bg.width
+                    height: itemDelegate.height
+                    radius: 8
+                    color: dropIndicator.ColorSelector.backgroundPalette
+                }
             }
 
             ItemDelegate {


### PR DESCRIPTION
1. Replaced Rectangle with Control component for better styling consistency
2. Moved visual properties to nested Rectangle for cleaner structure
3. Updated color property reference to use backgroundPalette
4. Maintained same visual appearance while improving code organization

fix: 改进 FreeSortListView 中的放置指示器实现

1. 用 Control 组件替换 Rectangle 以获得更好的样式一致性
2. 将视觉属性移至嵌套的 Rectangle 以获得更清晰的结构
3. 更新颜色属性引用以使用 backgroundPalette
4. 在改进代码组织的同时保持相同的视觉外观

Pms: BUG-320207

## Summary by Sourcery

Improve drop indicator implementation in FreeSortListView by replacing Rectangle with Control and reorganizing visual properties for styling consistency

Enhancements:
- Replace Rectangle with Control component for dropIndicator
- Nest width, height, radius, and color properties inside a child Rectangle
- Update color binding to use the Control's backgroundPalette