### PR TITLE
fix: adjust menu item margins in AppListView

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -304,9 +304,9 @@ FocusScope {
                 }
                 background: BoxPanel {
                     anchors.left: parent.left
-                    anchors.leftMargin: 10
+                    anchors.leftMargin: 2
                     anchors.right: parent.right
-                    anchors.rightMargin: 10
+                    anchors.rightMargin: 2
                     anchors.top: parent.top
                     anchors.bottom: parent.bottom
                     visible: menuItem.down || menuItem.hovered


### PR DESCRIPTION
Reduced left and right margins of menu item background from 10px to 2px to improve visual alignment and make better use of available space. The change creates a more compact and consistent appearance while maintaining hover/active state visibility.

fix: 调整 AppListView 中菜单项的边距

将菜单项背景的左右边距从 10px 减少到 2px，以改善视觉对齐并更好地利用可用
空间。此更改创建了更紧凑一致的外观，同时保持了悬停/活动状态的可见性。

Pms: BUG-318911