### PR TITLE
fix: prevent duplicate dock entries from launcher

### DIFF
--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -51,7 +51,8 @@ QtObject {
         if (!dockOnly) {
             mime["text/x-dde-launcher-dnd-desktopId"] = desktopId
         }
-        if (!DesktopIntegration.appIsDummyPackage(desktopId)) {
+        // 检查应用是否为虚拟包以及是否已经在任务栏中存在
+        if (!DesktopIntegration.appIsDummyPackage(desktopId) && !DesktopIntegration.isDockedApp(desktopId)) {
             mime["text/x-dde-dock-dnd-appid"] = desktopId
             mime["text/x-dde-dock-dnd-source"] = "launcher"
         }


### PR DESCRIPTION
1. Modified drag-and-drop handling in Helper.qml to check both dummy packages and existing dock entries
2. Added additional condition to verify app isn't already docked before adding to drag-and-drop data
3. This prevents duplicate entries when dragging apps from launcher to dock
4. The change maintains existing functionality while adding the new check

fix: 防止从启动器添加重复的停靠栏条目

1. 修改了 Helper.qml 中的拖放处理，同时检查虚拟包和已存在的停靠栏条目
2. 添加了额外条件，在添加到拖放数据前验证应用是否已停靠
3. 这防止了从启动器拖动应用到停靠栏时出现重复条目
4. 该变更在保持现有功能的同时添加了新检查

Pms: BUG-315721

## Summary by Sourcery

Bug Fixes:
- Add a condition in Helper.qml to skip apps that are already docked when handling drag-and-drop operations from the launcher.