### PR TITLE
feat: add display scaling support in desktop integration

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -249,6 +249,11 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
     connect(m_appearanceIntegration, &Appearance::opacityChanged, this, &DesktopIntegration::opacityChanged);
 }
 
+double DesktopIntegration::scaleFactor() const
+{
+    return m_appearanceIntegration->scaleFactor();
+}
+
 qreal DesktopIntegration::opacity() const
 {
     return m_appearanceIntegration->opacity();

--- a/desktopintegration.h
+++ b/desktopintegration.h
@@ -21,6 +21,7 @@ class DesktopIntegration : public QObject
     Q_PROPERTY(uint dockSpacing READ dockSpacing NOTIFY dockSpacingChanged)
     Q_PROPERTY(QString backgroundUrl READ backgroundUrl NOTIFY backgroundUrlChanged)
     Q_PROPERTY(qreal opacity READ opacity NOTIFY opacityChanged FINAL)
+    Q_PROPERTY(double scaleFactor READ scaleFactor NOTIFY scaleFactorChanged FINAL)
 
     QML_NAMED_ELEMENT(DesktopIntegration)
     QML_SINGLETON
@@ -66,6 +67,7 @@ public:
     Q_INVOKABLE void setAutoStart(const QString & desktopId, bool on = true);
     Q_INVOKABLE bool shouldSkipConfirmUninstallDialog(const QString & desktopId) const;
     Q_INVOKABLE void uninstallApp(const QString & desktopId);
+    Q_INVOKABLE double scaleFactor() const;
     qreal opacity() const;
 
 signals:
@@ -74,6 +76,7 @@ signals:
     void dockSpacingChanged();
     void backgroundUrlChanged();
     void opacityChanged();
+    void scaleFactorChanged();
 
 private:
     explicit DesktopIntegration(QObject * parent = nullptr);

--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -94,7 +94,7 @@ AppletItem {
             iconName: model.iconName,
             isFavoriteItem: false,
             hideFavoriteMenu: true,
-            hideDisplayScalingMenu: false,
+            hideDisplayScalingMenu: Math.abs(DesktopIntegration.scaleFactor - 1.0) < 0.0001,
             hideMoveToTopMenu: true
         }, additionalProps));
         menu.closed.connect(menu.destroy)

--- a/src/ddeintegration/appearance.cpp
+++ b/src/ddeintegration/appearance.cpp
@@ -150,3 +150,11 @@ void Appearance::setOpacity(qreal newOpacity)
     m_opacity = newOpacity;
     emit opacityChanged();
 }
+
+double Appearance::scaleFactor() const
+{
+    if (!m_dbusAppearanceIface || !m_dbusAppearanceIface->isValid()) {
+        return 1.0; // 默认返回1.0（100%缩放）
+    }
+    return m_dbusAppearanceIface->GetScaleFactor();
+}

--- a/src/ddeintegration/appearance.h
+++ b/src/ddeintegration/appearance.h
@@ -24,6 +24,8 @@ public:
     qreal opacity() const;
     void setOpacity(qreal newOpacity);
 
+    double scaleFactor() const;
+
 signals:
     void wallpaperBlurhashChanged();
 


### PR DESCRIPTION
1. Added scaleFactor() method to DesktopIntegration class to expose display scaling factor
2. Implemented scaleFactor() in Appearance class with DBus interface to get actual system scaling factor
3. Modified AppItemMenu.qml to only show scaling menu when scale factor is not 1.0 (100%)
4. Added default fallback value of 1.0 when DBus interface is not available

The changes allow proper handling of display scaling in the UI, particularly for the application menu where scaling options should only appear when needed (non-default scaling). This improves user experience on high-DPI displays.

feat: 在桌面集成中添加显示缩放支持

1. 在DesktopIntegration类中添加scaleFactor()方法以暴露显示缩放因子
2. 在Appearance类中实现scaleFactor()，通过DBus接口获取系统实际缩放因子
3. 修改AppItemMenu.qml，仅在缩放因子不为1.0(100%)时显示缩放菜单
4. 当DBus接口不可用时添加默认回退值1.0

这些更改使得UI能够正确处理显示缩放，特别是应用菜单中的缩放选项现在只会在
需要时(非默认缩放)出现。这提高了在高DPI显示器上的用户体验。

Pms: BUG-317063

## Summary by Sourcery

Expose and integrate display scaling support by exposing a scaleFactor API, fetching the system DPI scale via DBus with a fallback, and updating the application menu to show scaling options only when the factor is non-default.

New Features:
- Expose display scaling factor via scaleFactor() methods in DesktopIntegration and Appearance

Enhancements:
- Retrieve actual system scaling factor through DBus with a default fallback of 1.0