### PR TITLE
feat: add F1 key help support for launcher

### DIFF
--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -11,6 +11,8 @@
 #include <DGuiApplicationHelper>
 #include <QCommandLineParser>
 #include <launcher1adaptor.h>
+#include <QDBusMessage>
+#include <QDBusConnection>
 
 #include <private/qguiapplication_p.h>
 
@@ -188,4 +190,15 @@ void LauncherController::closeAllPopups()
 void LauncherController::setAvoidHide(bool avoidHide)
 {
     m_avoidHide = avoidHide;
+}
+
+void LauncherController::showHelp()
+{
+    // 由于当前只有调用 “启动器”，才能跳转到帮助文档的启动器目录。使用launcher 以及launchpad等字段，无法跳转到启动器目录。
+    QString helpTitle = "启动器";
+    
+    const QString &dmanInterface = "com.deepin.Manual.Open";
+    QDBusMessage message = QDBusMessage::createMethodCall(dmanInterface, "/com/deepin/Manual/Open", dmanInterface, "OpenTitle");
+    message << "dde" << helpTitle;
+    QDBusConnection::sessionBus().asyncCall(message);
 }

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -52,6 +52,7 @@ public:
     Q_INVOKABLE QFont adjustFontWeight(const QFont& f, QFont::Weight weight);
 
     Q_INVOKABLE void closeAllPopups();
+    Q_INVOKABLE void showHelp();
 
 signals:
     void currentFrameChanged();

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -68,6 +68,13 @@ InputEventItem {
         focus: true
         objectName: "FullscreenFrame-BaseLayer"
 
+        Shortcut {
+            context: Qt.ApplicationShortcut
+            sequences: [StandardKey.HelpContents, "F1"]
+            onActivated: LauncherController.showHelp()
+            onActivatedAmbiguously: LauncherController.showHelp()
+        }
+
         readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
         readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
 

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -22,6 +22,13 @@ InputEventItem {
 
     KeyNavigation.tab: appGridLoader.item
 
+    Shortcut {
+        context: Qt.ApplicationShortcut
+        sequences: [StandardKey.HelpContents, "F1"]
+        onActivated: LauncherController.showHelp()
+        onActivatedAmbiguously: LauncherController.showHelp()
+    }
+
     function getHorizontalCoordinatesOfSideBar()
     {
         return sideBar.x + sideBar.width / 2


### PR DESCRIPTION
1. Added showHelp() method in LauncherController to open manual via DBus
2. Implemented F1 key handling in both fullscreen and windowed modes
3. The help system specifically targets "启动器" (Launcher) section
4. Uses DBus interface com.deepin.Manual.Open to launch documentation
5. Added necessary DBus headers to launchercontroller.cpp

The change was made to provide quick access to launcher documentation through standard F1 help key, improving user experience and discoverability of launcher features.

feat: 为启动器添加F1键帮助支持

1. 在LauncherController中添加showHelp()方法通过DBus打开手册
2. 在全屏和窗口模式下实现F1键处理
3. 帮助系统专门针对"启动器"部分
4. 使用DBus接口com.deepin.Manual.Open启动文档
5. 在launchercontroller.cpp中添加必要的DBus头文件

此变更为用户提供通过标准F1帮助键快速访问启动器文档的功能，提升用户体验和
启动器功能的可发现性。
Pms: BUG-315751

## Summary by Sourcery

Add F1 key help support enabling quick access to launcher documentation via the com.deepin.Manual.Open DBus interface.

New Features:
- Introduce showHelp() in LauncherController to send a DBus call that opens the launcher section of the manual
- Implement F1 key handling in both fullscreen and windowed QML frames to trigger the launcher help