### PR TITLE
feat: add dark mode support for fullscreen context menu

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -36,6 +36,10 @@ Loader {
             rightMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.RightArrow ? dockSpacing : 0
             modal: true
 
+            // 在全屏模式下，右键菜单适配系统深浅模式
+            // 通过设置palette来实现主题适配
+            palette: DTK.palette
+
             MenuItem {
                 text: qsTr("Open")
                 enabled: !root.desktopId.startsWith("internal/folders/")


### PR DESCRIPTION
1. Added palette property to context menu in AppItemMenu.qml
2. The menu now adapts to system dark/light theme in fullscreen mode
3. Uses DTK.palette for consistent theming with the desktop environment
4. Ensures better visual integration with system appearance settings

feat: 为全屏上下文菜单添加深色模式支持

1. 在AppItemMenu.qml中为上下文菜单添加了palette属性
2. 菜单现在可以在全屏模式下适配系统的深色/浅色主题
3. 使用DTK.palette实现与桌面环境一致的主题效果
4. 确保与系统外观设置更好的视觉集成

Pms: BUG-326387

## Summary by Sourcery

Enable dark mode support for the fullscreen context menu by applying the desktop environment palette.

New Features:
- Adapt the fullscreen context menu to the system dark/light theme
- Apply DTK.palette to AppItemMenu.qml for consistent theming