### PR TITLE
feat: add alwaysShowHighlighted property to GridViewContainer

### DIFF
--- a/qml/windowed/GridViewContainer.qml
+++ b/qml/windowed/GridViewContainer.qml
@@ -22,6 +22,7 @@ FocusScope {
     property alias delegate: gridView.delegate
     property alias interactive: gridView.interactive
     property alias gridViewFocus: gridView.focus
+    property bool alwaysShowHighlighted: false
     property alias gridViewClip: gridView.clip
     property bool activeGridViewFocusOnTab: false
     property int columns: 4
@@ -99,6 +100,15 @@ FocusScope {
                     radius: 8
                     color: parent.palette.highlight
                     visible: gridView.activeFocus
+                }
+                Rectangle {
+                    anchors {
+                        fill: parent
+                        margins: 5
+                    }
+                    radius: 8
+                    color: DTK.themeType === ApplicationHelper.DarkType ? Qt.rgba(1, 1, 1, 0.1) : Qt.rgba(0, 0, 0, 0.1)
+                    visible: alwaysShowHighlighted
                 }
             }
 

--- a/qml/windowed/SearchResultView.qml
+++ b/qml/windowed/SearchResultView.qml
@@ -65,6 +65,7 @@ Control {
             Layout.preferredHeight: searchResultViewContainer.height
             Layout.preferredWidth: searchResultViewContainer.width
             interactive: true
+            alwaysShowHighlighted: true
 
             model: delegateSearchResultModel
 


### PR DESCRIPTION
1. Added new property alwaysShowHighlighted to control visibility of highlight rectangle
2. Implemented visual highlight effect with semi-transparent white rectangle when enabled
3. Enabled this property by default in SearchResultView for better visual feedback
4. The highlight has rounded corners (radius: 8) and 5px margins from item edges
5. This improves UI visibility especially in search results where focus indication is important

feat: 为 GridViewContainer 添加 alwaysShowHighlighted 属性

1. 新增 alwaysShowHighlighted 属性用于控制高亮矩形的可见性
2. 当启用时实现半透明白色矩形的高亮视觉效果
3. 在 SearchResultView 中默认启用该属性以提供更好的视觉反馈
4. 高亮效果具有圆角(半径:8)和距离边缘5px的边距
5. 这提升了UI可见性，特别是在需要焦点指示的搜索结果中

Pms: BUG-327065

## Summary by Sourcery

Add a new alwaysShowHighlighted property to GridViewContainer to control a persistent highlight overlay, implement its visual style, and enable it by default in SearchResultView for improved focus indication.

New Features:
- Add alwaysShowHighlighted property to GridViewContainer to toggle a persistent highlight rectangle
- Render a semi-transparent white rounded highlight overlay with 5px margins and 8px corner radius when alwaysShowHighlighted is enabled
- Enable alwaysShowHighlighted by default in SearchResultView to enhance focus visibility in search results