### PR TITLE
fix: modify confirm to uninstall.

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -337,7 +337,7 @@ AppletItem {
                 Item {
                     WarningButton {
                         id: confirmButton
-                        text: qsTr("Confirm")
+                        text: qsTr("Uninstall")
                         onClicked: {
                             DesktopIntegration.uninstallApp(confirmUninstallDlg.appId)
                             confirmUninstallDlg.close()

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
@@ -4,72 +4,58 @@
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation type="unfinished"></translation>
     </message>
@@ -77,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -95,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -108,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation type="unfinished"></translation>
     </message>
@@ -116,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -197,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -205,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -219,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation type="unfinished"></translation>
     </message>
@@ -267,78 +219,63 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
+        <source>Uninstall</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Aç</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Yuxarına qov</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Yuxarıya köç</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Sevimlilərdən çıxar</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Sevimlilərə əlavə et</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>İş Masasından silmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>İş Masasına göndərmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Dok-dan silmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Dok-a göndərmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Avtobaşlatmadan silmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Avtobaşlatmaya əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Proksi istifadə etmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Göstərəc särilmasını etkin etmək</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Sil</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Şəkildə nəticə</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Yüklə</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Sil</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Çox istifadə edilən</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Pencərə rejimi</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Oyunlar</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Digər</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Təsdiq et</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Son yüklənən</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Bütün uquanlar</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Axtarış nəticəsi tapılmadı</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Üzvləşdirilməz təbii sıralama</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Kategoriyalara görə sırala</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Ada görə sırala</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Sıralama rejimi</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Müvəffəqiyətli təbii sıralama</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Şəkillər</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Janrillər</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Masaüstü</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Kontrol Çərçivəsi</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Oyunlar</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Başqa</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Təsdiq et</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Sil</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
@@ -4,129 +4,73 @@
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>ཁ་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>ཅོག་ངོས་སུ་བསྐུར་བ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>ཅོག་ངོས་ནས་བསུབ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>ལས་འགན་ཚན་བྱང་དུ་བསྐུར་བ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>ལས་འགན་ཚན་བྱང་ནས་བསུབ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>རང་འགུལ་གྱིས་ཕྱེ་བ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>རང་འགུལ་གྱིས་ཕྱེ་བ་མེད་པར་བཟོ་བ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>ལས་ཚབ་སྤྱོད་པ།</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>བཤིག་འདོན།</translation>
     </message>
 </context>
 <context>
-    <name>AppListView</name>
-    <message>
-        <source>Internet</source>
-        <translation type="vanished">དྲ་བ།</translation>
-    </message>
-    <message>
-        <source>Chat</source>
-        <translation type="vanished">གླེང་མོལ།</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation type="vanished">རོལ་མོ།</translation>
-    </message>
-    <message>
-        <source>Video</source>
-        <translation type="vanished">བརྙན་འཕྲིན།</translation>
-    </message>
-    <message>
-        <source>Graphics</source>
-        <translation type="vanished">རི་མོ།</translation>
-    </message>
-    <message>
-        <source>Office</source>
-        <translation type="vanished">གཞུང་ལས།</translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="vanished">ཀློག་འདོན།</translation>
-    </message>
-    <message>
-        <source>Development</source>
-        <translation type="vanished">གསར་སྤེལ།</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation type="vanished">རྒྱུད་ཁོངས།</translation>
-    </message>
-</context>
-<context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation type="unfinished">གློག་ཁུངས།</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation type="unfinished">བཤེར་འཚོལ།</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -134,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -147,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,11 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <source>Search</source>
-        <translation type="obsolete">བཤེར་འཚོལ།</translation>
-    </message>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -167,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation type="unfinished">དྲ་བ།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation type="unfinished">གླེང་མོལ།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation type="unfinished">རོལ་མོ།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation type="unfinished">བརྙན་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation type="unfinished">རི་མོ།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation type="unfinished">གཞུང་ལས།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation type="unfinished">ཀློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation type="unfinished">གསར་སྤེལ།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation type="unfinished">རྒྱུད་ཁོངས།</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -240,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -248,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -262,142 +180,103 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>WindowedFrame</name>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">གློག་ཁུངས།</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation type="vanished">སྒྲིག་འགོད།</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">བཤེར་འཚོལ།</translation>
-    </message>
-</context>
-<context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation type="unfinished">དྲ་བ།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation type="unfinished">གླེང་མོལ།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation type="unfinished">རོལ་མོ།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation type="unfinished">བརྙན་འཕྲིན།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation type="unfinished">རི་མོ།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation type="unfinished">གཞུང་ལས།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation type="unfinished">ཀློག་འདོན།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation type="unfinished">གསར་སྤེལ།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation type="unfinished">རྒྱུད་ཁོངས།</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">བཤིག་འདོན།</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Obre</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Fixa-ho a dalt</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Mou-ho a dalt</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Elimina-ho dels favorits</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Afegeix-ho als favorits</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Elimina de l&apos;escriptori</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Enviar a l&apos;escriptori</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Elimina de l&apos;acoblador</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Envia a l&apos;acoblador</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Eliminar de l&apos;arrencada</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Afegir a l&apos;arrencada</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Usa un servidor intermediari</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Inhabilita l&apos;escalatge de la pantalla</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Desinstal·la</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Cerca</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Mode de pantalla completa</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Instal·la</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Elimina</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Usat amb freqüència</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Mode de finestra</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Xat</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Gràfics</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Jocs</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Oficina</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Desenvolupament</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Altres</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Segur que voleu desinstal·lar %1?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Confirmeu-ho</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Instal·lat recentment</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Totes les aplicacions</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>No hi ha resultats de la cerca.</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Classificació lliure</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Ordena per categoria</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Ordena per nom</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Mode de classificació</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Ordinador</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Imatges</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Documents</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Escriptori</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Centre de control</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Xat</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Gràfics</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Jocs</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Oficina</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Desenvolupament</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Altres</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>plataforma de llançament</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Segur que voleu desinstal·lar %1?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Confirmeu-ho</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Desinstal·la</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Anclar arriba</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Mover al inicio</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de Favoritos</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Añadir a Favoritos</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Quitar del escritorio</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Enviar al escritorio</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Desanclar del muelle</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Anclar al muelle</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Quitar del arranque</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Añadir al arranque</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Usar un proxy</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Desactivar escalado de pantalla</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Desinstalar</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Encender</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Modo pantalla completa</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Uso frecuente</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Modo ventana</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Mensajería</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Juegos</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Ofimática</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Desarrollo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Otros</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>¿Desea desinstalar «%1»?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Instalado recientemente</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Todas las aplicaciones</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Sin resultados</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Ordenar libremente</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Ordenar por categoría</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Ordenar por nombre</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Modo clasificación</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Equipo</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Documentos</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Escritorio</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Centro de control</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Mensajería</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Juegos</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Ofimática</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Lectura</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Desarrollo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Otros</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>¿Desea desinstalar «%1»?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Confirmar</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Desinstalar</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Avaa</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Kiinnitä ylös</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Poista suosikeista</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Lisää suosikkeihin</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Poista työpöydältä</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Kiinnitä työpöydälle</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Poista telakasta</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Kiinnitä telakkaan</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Poista käynnistyksestä</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Lisää käynnistykseen</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Käytä välityspalvelinta</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Poista näytön skaalaus</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Poista</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Virta</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Hae</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Koko näyttö</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Asenna</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Poista</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Usein käytetty</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Ikkunatila</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Keskustelu</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Musiikki</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Grafiikka</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Pelit</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Toimisto</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Lukeminen</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Ohjelmointi</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Järjestelmä</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Muut</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Haluatko poistaa &quot;%1&quot; asennuksen?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Vahvista</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Hiljattain asennettu</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Kaikki sovellukset</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Ei hakutuloksia</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Vapaa lajittelu</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Luokan mukaan</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Nimen mukaan</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Lajittelutila</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Tietokone</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Kuvat</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Asiakirjat</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Työpöytä</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Ohjauspaneli</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Keskustelu</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Musiikki</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Grafiikka</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Pelit</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Toimisto</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Lukeminen</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Ohjelmointi</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Järjestelmä</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Muut</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Haluatko poistaa &quot;%1&quot; asennuksen?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Peruuta</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Vahvista</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Poista</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Épingler en haut</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Déplacer vers le haut</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Retirer des favoris</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Supprimer du bureau</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Envoyer sur le bureau</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Supprimer du dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Épingler au dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Supprimer du démarrage</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Ajouter au démarrage</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Utiliser un proxy</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Désactivez la mise à l&apos;échelle de l&apos;affichage</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Désinstaller</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Alimentation</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Mode plein écran</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Installer</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Retirer</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Utilisé souvent</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Mode fenêtre</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Discussion</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Musique</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Vidéo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Graphisme</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Jeux</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Bureautique</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Lecture</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Développement</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Êtes-vous sûr de vouloir désinstaller &quot;%1&quot; ?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Confirmer</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Installé récemment</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Toutes les application</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Aucun résultat trouvé</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Tri libre</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Trier par catégorie</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Trier par nom</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Mode de tri</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Ordinateur</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Images</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Documents</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Bureau</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Centre de contrôle</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Discussion</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Musique</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Vidéo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Graphisme</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Jeux</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Bureautique</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Lecture</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Développement</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Système</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>Launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Êtes-vous sûr de vouloir désinstaller &quot;%1&quot; ?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Confirmer</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Désinstaller</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Megnyitás</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Rögzítés a tetejére</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Ugrás a tetejére</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Eltávolítás a kedvencekből</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Hozzáadás a kedvencekhez</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Eltávolítás az asztalról</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Küldés az asztalra</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Eltávolítás a Dokkolóról</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Küldés a Dokkolóra</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Eltávolítás az automatikus indításból</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Hozzáadás az automatikus indításhoz</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Proxy használata</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Képernyő méretezés letiltása</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Eltávolítás</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Kikapcsolás</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Teljes képernyős használat</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Telepítés</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Eltávolítás</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Gyakran Használt</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Ablak Mód</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Csevegés</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Zene</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Videó</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Grafika</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Játékok</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Iroda</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Olvasás</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Fejlesztés</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Rendszer</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Egyéb</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Megerősítés</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Újonnan Telepített</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Minden alkalmazás</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Nincs keresési eredmény</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Szabad rendezés</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Rendezés Kategóriánként</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Rendezés név szerint</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Rendezési Mód</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Számítógép</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Képek</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Dokumentumok</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Asztal</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Vezérlőpult</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Világháló</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Csevegés</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Zene</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Videó</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Grafika</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Játékok</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Iroda</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Olvasás</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Fejlesztés</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Rendszer</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Egyéb</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>indítópult</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Mégse</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Megerősít</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Eltávolítás</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
@@ -2,138 +2,75 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="it">
 <context>
-    <name>AnalysisView</name>
-    <message>
-        <source>No search results</source>
-        <translation type="obsolete">Nessun risultato disponibile</translation>
-    </message>
-</context>
-<context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Invia al desktop</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Rimuovi dal desktop</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Rimuovi dalla dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Invia alla dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Aggiungi all&apos;avvio automatico</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Rimuovi dall&apos;avvio automatico</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Usa un proxy</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Disinstalla</translation>
     </message>
 </context>
 <context>
-    <name>AppListView</name>
-    <message>
-        <source>Internet</source>
-        <translation type="vanished">Internet</translation>
-    </message>
-    <message>
-        <source>Chat</source>
-        <translation type="vanished">Chat</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation type="vanished">Musica</translation>
-    </message>
-    <message>
-        <source>Video</source>
-        <translation type="vanished">Video</translation>
-    </message>
-    <message>
-        <source>Graphics</source>
-        <translation type="vanished">Grafica</translation>
-    </message>
-    <message>
-        <source>Office</source>
-        <translation type="vanished">Ufficio</translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="vanished">Lettura</translation>
-    </message>
-    <message>
-        <source>Development</source>
-        <translation type="vanished">Sviluppo</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation type="vanished">Sistema</translation>
-    </message>
-</context>
-<context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation type="unfinished">Alimentazione</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation type="unfinished">Cerca</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -141,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,23 +89,13 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>All Apps</source>
-        <translation type="obsolete">Tutte le app</translation>
     </message>
 </context>
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <source>Search</source>
-        <translation type="obsolete">Cerca</translation>
-    </message>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -178,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation type="unfinished">Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation type="unfinished">Chat</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation type="unfinished">Musica</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation type="unfinished">Video</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation type="unfinished">Grafica</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation type="unfinished">Ufficio</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation type="unfinished">Lettura</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation type="unfinished">Sviluppo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation type="unfinished">Sistema</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -259,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation type="unfinished">Tutte le app</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished">Nessun risultato disponibile</translation>
     </message>
@@ -273,154 +180,103 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>WindowedFrame</name>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Alimentazione</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation type="vanished">Impostazioni</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Cerca</translation>
-    </message>
-    <message>
-        <source>My Favorites</source>
-        <translation type="vanished">I miei Preferiti</translation>
-    </message>
-    <message>
-        <source>All Apps</source>
-        <translation type="vanished">Tutte le app</translation>
-    </message>
-    <message>
-        <source>No search results</source>
-        <translation type="vanished">Nessun risultato disponibile</translation>
-    </message>
-</context>
-<context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation type="unfinished">Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation type="unfinished">Chat</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation type="unfinished">Musica</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation type="unfinished">Video</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation type="unfinished">Grafica</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation type="unfinished">Ufficio</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation type="unfinished">Lettura</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation type="unfinished">Sviluppo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation type="unfinished">Sistema</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Disinstalla</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>上部に固定</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>上部に移動</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>デスクトップから削除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>デスクトップに追加</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>ドックから削除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>ドックに固定</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>スタートアップから削除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>スタートアップへ追加</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>プロキシを使う</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>ディスプレイスケーリングを無効化</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>アンインストール</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>電源</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>検索</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>全画面モード</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>インストール</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>削除</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>最近使用したもの</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>ウィンドウ モード</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>インターネット</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>チャット</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>ミュージック</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>ビデオ</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>グラフィックス</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>ゲーム</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>オフィス</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>文書</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>開発</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>システム</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>その他</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>%1 をアンインストールしてもよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>最近インストールされたもの</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>すべてのアプリ</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>検索結果はありません</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>フリー並び替え</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>カテゴリで並べ替え</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>名前で並べ替え</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>並び替えモード</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>コンピューター</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>ピクチャー</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>ドキュメント</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>デスクトップ</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>コントロールセンター</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>インターネット</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>チャット</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>ミュージック</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>ビデオ</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>グラフィックス</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>ゲーム</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>オフィス</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>文書</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>開発</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>システム</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>その他</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>ランチャー</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>%1 をアンインストールしてもよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>確認</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">アンインストール</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
@@ -4,129 +4,73 @@
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>바탕화면으로 보내기</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>바탕화면에서 제거</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>도구집에서 제거</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>도구집으로 보내기</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>시작에 추가하기</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>시작에서 제거하기</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>프록시 사용</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>제거</translation>
     </message>
 </context>
 <context>
-    <name>AppListView</name>
-    <message>
-        <source>Internet</source>
-        <translation type="vanished">인터넷</translation>
-    </message>
-    <message>
-        <source>Chat</source>
-        <translation type="vanished">채팅</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation type="vanished">음악</translation>
-    </message>
-    <message>
-        <source>Video</source>
-        <translation type="vanished">동영상</translation>
-    </message>
-    <message>
-        <source>Graphics</source>
-        <translation type="vanished">그래픽</translation>
-    </message>
-    <message>
-        <source>Office</source>
-        <translation type="vanished">오피스</translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="vanished">읽기</translation>
-    </message>
-    <message>
-        <source>Development</source>
-        <translation type="vanished">개발</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation type="vanished">시스템</translation>
-    </message>
-</context>
-<context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation type="unfinished">전원</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation type="unfinished">찾기</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -134,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -147,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -163,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation type="unfinished">인터넷</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation type="unfinished">채팅</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation type="unfinished">음악</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation type="unfinished">동영상</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation type="unfinished">그래픽</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation type="unfinished">오피스</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation type="unfinished">읽기</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation type="unfinished">개발</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation type="unfinished">시스템</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -236,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -244,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -258,142 +180,103 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>WindowedFrame</name>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">전원</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation type="vanished">설정</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">찾기</translation>
-    </message>
-</context>
-<context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation type="unfinished">인터넷</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation type="unfinished">채팅</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation type="unfinished">음악</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation type="unfinished">동영상</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation type="unfinished">그래픽</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation type="unfinished">오피스</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation type="unfinished">읽기</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation type="unfinished">개발</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation type="unfinished">시스템</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">제거</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
@@ -2,138 +2,75 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nb_NO">
 <context>
-    <name>AnalysisView</name>
-    <message>
-        <source>No search results</source>
-        <translation type="obsolete">Ingen søkeresultater</translation>
-    </message>
-</context>
-<context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Åpne</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Send til skrivebord</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Fjern fra skrivebordet</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Send til dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Fjern fra dokk</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Legg til oppstart</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Fjern fra oppstart</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Bruk en Proxy</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Avinstaller</translation>
     </message>
 </context>
 <context>
-    <name>AppListView</name>
-    <message>
-        <source>Internet</source>
-        <translation type="vanished">Internett</translation>
-    </message>
-    <message>
-        <source>Chat</source>
-        <translation type="vanished">Chat</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation type="vanished">Musikk</translation>
-    </message>
-    <message>
-        <source>Video</source>
-        <translation type="vanished">Video</translation>
-    </message>
-    <message>
-        <source>Graphics</source>
-        <translation type="vanished">Grafikk</translation>
-    </message>
-    <message>
-        <source>Office</source>
-        <translation type="vanished">Kontor</translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="vanished">Lesing</translation>
-    </message>
-    <message>
-        <source>Development</source>
-        <translation type="vanished">Utvikling</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation type="vanished">System</translation>
-    </message>
-</context>
-<context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation type="unfinished">Strøm</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation type="unfinished">Søk</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -141,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,23 +89,13 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>All Apps</source>
-        <translation type="obsolete">Alle programmer</translation>
     </message>
 </context>
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <source>Search</source>
-        <translation type="obsolete">Søk</translation>
-    </message>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -178,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation type="unfinished">Internett</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation type="unfinished">Chat</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation type="unfinished">Musikk</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation type="unfinished">Video</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation type="unfinished">Grafikk</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation type="unfinished">Kontor</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation type="unfinished">Lesing</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation type="unfinished">Utvikling</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation type="unfinished">System</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -251,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -259,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation type="unfinished">Alle programmer</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation type="unfinished">Ingen søkeresultater</translation>
     </message>
@@ -273,154 +180,103 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>WindowedFrame</name>
-    <message>
-        <source>Power</source>
-        <translation type="vanished">Strøm</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation type="vanished">Instillinger</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Søk</translation>
-    </message>
-    <message>
-        <source>My Favorites</source>
-        <translation type="vanished">Mine favoritter</translation>
-    </message>
-    <message>
-        <source>All Apps</source>
-        <translation type="vanished">Alle programmer</translation>
-    </message>
-    <message>
-        <source>No search results</source>
-        <translation type="vanished">Ingen søkeresultater</translation>
-    </message>
-</context>
-<context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation type="unfinished">Internett</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation type="unfinished">Chat</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation type="unfinished">Musikk</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation type="unfinished">Video</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation type="unfinished">Grafikk</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation type="unfinished">Kontor</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation type="unfinished">Lesing</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation type="unfinished">Utvikling</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation type="unfinished">System</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation type="unfinished"></translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Avinstaller</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Otwórz</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Przypnij na górze</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Przenieś na górę</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Usuń z ulubionych</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Dodaj do ulubionych</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Usuń z pulpitu</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Wyślij na pulpit</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Usuń z doku</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Dodaj do doku</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Usuń z startu systemu</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Dodaj do startu systemu</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Użyj proxy</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Wyłącz skalowanie ekranu</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Odinstaluj</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Zasilanie</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Szukaj</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Tryb pełnoekranowy</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Zainstaluj</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Usuń</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Często używane</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Tryb okna</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Rozmowy</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Muzyka</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Wideo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Grafika</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Gry</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Biuro</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Czytanie</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Programowanie</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Inne</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Czy na pewno odinstalować &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Ostatnio zainstalowane</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Wszystkie aplikacje</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Brak wyników wyszukiwania</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Swobodne sortowanie</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Sortuj wg. kategorii</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Sortuj wg. nazwy</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Tryb sortowania</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Komputer</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Zdjęcia</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Dokumenty</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Pulpit</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Centrum kontroli</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Komunikacja</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Muzyka</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Wideo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Grafika</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Gry</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Biurowe</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Czytanie</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Programowanie</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Inne</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>Launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Czy na pewno odinstalować &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Potwierdź</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Odinstaluj</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Fixar no topo</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Mover para o topo</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Remover dos favoritos</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Adicionar aos favoritos</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Remover da área de trabalho</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Enviar para área de trabalho</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Remover do dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Fixar no dock</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Remover da inicialização</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Adicionar à inicialização</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Usar proxy</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Desativar escala de exibição</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Desinstalar</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Energia</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Pesquisar</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Modo tela cheia</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Usado frequentemente</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Modo janela</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Comunicação</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Imagem</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Jogos</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Produtividade</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Leitura</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Desenvolvimento</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Outros</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Desinstalar &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Instalado recentemente</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Todos os aplicativos</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Nenhum resultado encontrado</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Classificação livre</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Classificar por categoria</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Classificar por nome</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Modo de classificação</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Computador</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Imagens</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Documentos</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Área de Trabalho</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Central de Controle</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Bate papo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Vídeo</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Jogos</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Escritório</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Leitura</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Desenvolvimento</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Outros</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>Launchpad</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Desinstalar &quot;%1&quot;?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Confirmar</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Desinstalar</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Открыть</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Закрепить сверху</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Удалить из избранного</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Добавить в избранное</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Удалить с рабочего стола</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Отправить на рабочий стол</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Убрать из дока</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Отправить в док</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Удалить из автозагрузки</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Добавить в автозагрузку</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Использовать прокси</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Отключить маштабирование дисплея</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Удалить</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Питание</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Полноэкранный режим</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Часто используемое</translation>
     </message>
@@ -114,80 +96,65 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Интернет</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Чат</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Музыка</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Видео</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Графика</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Офис</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Чтение</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Разработка</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Прочее</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Подтвердить</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Недавно установленное</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Все приложения</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Ничего не найдено</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Свободная сортировка</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Сортировать по категориям</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Сортировать по имени</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Оконный режим</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Компьютер</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Картинки</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Документы</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Рабочий Стол</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Центр управления</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Интернет</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Чат</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Музыка</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Видео</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Графика</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Офис</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Чтение</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Разработка</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Система</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Прочее</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation type="unfinished"/>
+        <source>Uninstall</source>
+        <translation type="unfinished">Удалить</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>Пришпилити нагорі</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>Пересунути нагору</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>Вилучити з вибраного</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>Видалити з стільниці</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>Надіслати на стільницю</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>Видалити з док-панелі</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>Надіслати на панель</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>Вилучити із запуску</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>Додати до запуску</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>Використовувати проксі</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>Вимкнути масштабування дисплею</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>Видалити</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>Живлення</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>Пошук</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>Повноекранний режим</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>Встановити</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>Вилучити</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>Часто використані</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>Режим вікна</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>Інтернет</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>Спілкування</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>Музика</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>Відео</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>Графіка</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>Ігри</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>Офіс</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>Читання</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>Розробка</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>Інше</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Ви справді хочете вилучити «%1»?</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>Нещодавно встановлені</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>Усі програми</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>Нічого не знайдено</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>Довільне упорядкування</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>Упорядкування за категоріями</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>Упорядкування за назвами</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>Режим упорядковування</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>Комп&apos;ютер</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>Зображення</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>Документи</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>Стільниця</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>Центр керування</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>Інтернет</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>Спілкування</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>Музика</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>Відео</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>Графіка</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>Ігри</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>Офіс</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>Читання</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>Розробка</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>Система</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>Інше</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>пусковий стіл</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>Ви справді хочете вилучити «%1»?</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>Підтвердити</translation>
+        <source>Uninstall</source>
+        <translation type="unfinished">Видалити</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
@@ -1,73 +1,61 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AppItemMenu</name>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
         <source>Pin to Top</source>
         <translation>移到顶部</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
         <source>Move to Top</source>
         <translation>移至顶部</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Remove from desktop</source>
         <translation>从桌面上移除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
         <source>Send to desktop</source>
         <translation>发送到桌面</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Remove from dock</source>
         <translation>从任务栏上移除</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
         <source>Send to dock</source>
         <translation>发送到任务栏</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Remove from startup</source>
         <translation>取消开机自动启动</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
         <source>Add to startup</source>
         <translation>开机自动启动</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
         <source>Use a proxy</source>
         <translation>使用代理</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
         <source>Disable display scaling</source>
         <translation>禁用屏幕缩放</translation>
     </message>
     <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
         <source>Uninstall</source>
         <translation>卸载</translation>
     </message>
@@ -75,17 +63,14 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
         <source>Power</source>
         <translation>电源</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
         <source>Search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
         <source>Full-screen Mode</source>
         <translation>全屏模式</translation>
     </message>
@@ -93,12 +78,10 @@
 <context>
     <name>DummyAppItemMenu</name>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
         <source>Install</source>
         <translation>安装</translation>
     </message>
     <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
@@ -106,7 +89,6 @@
 <context>
     <name>FrequentlyUsedView</name>
     <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
         <source>Frequently Used</source>
         <translation>我的常用</translation>
     </message>
@@ -114,7 +96,6 @@
 <context>
     <name>FullscreenFrame</name>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
         <source>Window Mode</source>
         <translation>窗口模式</translation>
     </message>
@@ -122,72 +103,58 @@
 <context>
     <name>Main</name>
     <message>
-        <location filename="../../qml/Main.qml" line="22"/>
         <source>Internet</source>
         <translation>网络应用</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="24"/>
         <source>Chat</source>
         <translation>社交沟通</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="26"/>
         <source>Music</source>
         <translation>音乐欣赏</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="28"/>
         <source>Video</source>
         <translation>视频播放</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="30"/>
         <source>Graphics</source>
         <translation>图形图像</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="32"/>
         <source>Games</source>
         <translation>游戏娱乐</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="34"/>
         <source>Office</source>
         <translation>办公学习</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="36"/>
         <source>Reading</source>
         <translation>阅读翻译</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="38"/>
         <source>Development</source>
         <translation>编程开发</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="40"/>
         <source>System</source>
         <translation>系统管理</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="42"/>
         <source>Others</source>
         <translation>其他应用</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="400"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>您确定要卸载“%1”吗？</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="412"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../../qml/Main.qml" line="426"/>
         <source>Confirm</source>
         <translation>确 定</translation>
     </message>
@@ -195,7 +162,6 @@
 <context>
     <name>RecentlyInstalledView</name>
     <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
         <source>Recently Installed</source>
         <translation>最近安装</translation>
     </message>
@@ -203,13 +169,10 @@
 <context>
     <name>SearchResultView</name>
     <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
         <source>All Apps</source>
         <translation>所有应用</translation>
     </message>
     <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
         <source>No search results</source>
         <translation>无搜索结果</translation>
     </message>
@@ -217,47 +180,38 @@
 <context>
     <name>SideBar</name>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
         <source>Free sorting</source>
         <translation>自由排序</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
         <source>Sort by category</source>
         <translation>按分类</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
         <source>Sort by name</source>
         <translation>按名称</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
         <source>Sorting Mode</source>
         <translation>排序模式</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
         <source>Computer</source>
         <translation>计算机</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
         <source>Pictures</source>
         <translation>图片</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
         <source>Documents</source>
         <translation>文档</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
         <source>Desktop</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
         <source>Control Center</source>
         <translation>控制中心</translation>
     </message>
@@ -265,79 +219,64 @@
 <context>
     <name>launcheritem</name>
     <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
         <source>Internet</source>
         <translation>网络应用</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
         <source>Chat</source>
         <translation>社交沟通</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
         <source>Music</source>
         <translation>音乐欣赏</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
         <source>Video</source>
         <translation>视频播放</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
         <source>Graphics</source>
         <translation>图形图像</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
         <source>Games</source>
         <translation>游戏娱乐</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
         <source>Office</source>
         <translation>办公学习</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
         <source>Reading</source>
         <translation>阅读翻译</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
         <source>Development</source>
         <translation>编程开发</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
         <source>System</source>
         <translation>系统管理</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
         <source>Others</source>
         <translation>其他应用</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
         <source>launchpad</source>
         <translation>启动器</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
         <translation>您确定要卸载“%1”吗？</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
         <source>Cancel</source>
         <translation>取 消</translation>
     </message>
     <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>确 定</translation>
+        <source>Uninstall</source>
+        <translation>卸 载</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
@@ -1,343 +1,282 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
-<context>
-    <name>AppItemMenu</name>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
-        <source>Open</source>
-        <translation>打開</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
-        <source>Pin to Top</source>
-        <translation>移到頂部</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
-        <source>Move to Top</source>
-        <translation>移至頂部</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
-        <source>Remove from favorites</source>
-        <translation>從收藏中移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
-        <source>Add to favorites</source>
-        <translation>添加到收藏</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
-        <source>Remove from desktop</source>
-        <translation>從桌面移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
-        <source>Send to desktop</source>
-        <translation>傳送到桌面</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
-        <source>Remove from dock</source>
-        <translation>從任務欄移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
-        <source>Send to dock</source>
-        <translation>傳送到任務欄</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
-        <source>Remove from startup</source>
-        <translation>從開機啟動中移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
-        <source>Add to startup</source>
-        <translation>加至開機啟動</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
-        <source>Use a proxy</source>
-        <translation>使用代理</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
-        <source>Disable display scaling</source>
-        <translation>禁用屏幕縮放</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
-        <source>Uninstall</source>
-        <translation>卸載</translation>
-    </message>
-</context>
-<context>
-    <name>BottomBar</name>
-    <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
-        <source>Power</source>
-        <translation>電源</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
-        <source>Full-screen Mode</source>
-        <translation>全螢幕模式</translation>
-    </message>
-</context>
-<context>
-    <name>DummyAppItemMenu</name>
-    <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
-        <source>Install</source>
-        <translation>安裝</translation>
-    </message>
-    <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
-        <source>Remove</source>
-        <translation>移除</translation>
-    </message>
-</context>
-<context>
-    <name>FrequentlyUsedView</name>
-    <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
-        <source>Frequently Used</source>
-        <translation>我的常用</translation>
-    </message>
-</context>
-<context>
-    <name>FullscreenFrame</name>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
-        <source>Window Mode</source>
-        <translation>窗口模式</translation>
-    </message>
-</context>
-<context>
-    <name>Main</name>
-    <message>
-        <location filename="../../qml/Main.qml" line="22"/>
-        <source>Internet</source>
-        <translation>網際網路</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="24"/>
-        <source>Chat</source>
-        <translation>社交溝通</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="26"/>
-        <source>Music</source>
-        <translation>音樂欣賞</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="28"/>
-        <source>Video</source>
-        <translation>影片播放</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="30"/>
-        <source>Graphics</source>
-        <translation>美工繪圖</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="32"/>
-        <source>Games</source>
-        <translation>遊戲娛樂</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="34"/>
-        <source>Office</source>
-        <translation>文書處理</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="36"/>
-        <source>Reading</source>
-        <translation>閱讀翻譯</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="38"/>
-        <source>Development</source>
-        <translation>程式開發</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="40"/>
-        <source>System</source>
-        <translation>系統管理</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="42"/>
-        <source>Others</source>
-        <translation>其他應用</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation>您確定要卸載“%1”嗎？</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="412"/>
-        <source>Cancel</source>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="426"/>
-        <source>Confirm</source>
-        <translation>確 定</translation>
-    </message>
-</context>
-<context>
-    <name>RecentlyInstalledView</name>
-    <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
-        <source>Recently Installed</source>
-        <translation>最近安裝</translation>
-    </message>
-</context>
-<context>
-    <name>SearchResultView</name>
-    <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
-        <source>All Apps</source>
-        <translation>所有應用</translation>
-    </message>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
-        <source>No search results</source>
-        <translation>無搜索結果</translation>
-    </message>
-</context>
-<context>
-    <name>SideBar</name>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
-        <source>Free sorting</source>
-        <translation>自由排序</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
-        <source>Sort by category</source>
-        <translation>按分類</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
-        <source>Sort by name</source>
-        <translation>按名稱</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
-        <source>Sorting Mode</source>
-        <translation>排序模式</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
-        <source>Computer</source>
-        <translation>計算機</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
-        <source>Pictures</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
-        <source>Documents</source>
-        <translation>文檔</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
-        <source>Control Center</source>
-        <translation>控制中心</translation>
-    </message>
-</context>
-<context>
-    <name>launcheritem</name>
-    <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
-        <source>Internet</source>
-        <translation>網絡應用</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
-        <source>Chat</source>
-        <translation>社交溝通</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
-        <source>Music</source>
-        <translation>音樂欣賞</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
-        <source>Video</source>
-        <translation>影片播放</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
-        <source>Graphics</source>
-        <translation>圖形圖像</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
-        <source>Games</source>
-        <translation>遊戲娛樂</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
-        <source>Office</source>
-        <translation>辦公學習</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
-        <source>Reading</source>
-        <translation>閱讀翻譯</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
-        <source>Development</source>
-        <translation>程式開發</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
-        <source>System</source>
-        <translation>系統管理</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
-        <source>Others</source>
-        <translation>其他應用</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
-        <source>launchpad</source>
-        <translation>啓動器</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
-        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation>您確定要卸載“%1”嗎？</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
-        <source>Cancel</source>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>確 定</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_HK" version="2.1">
+    <context>
+        <name>AppItemMenu</name>
+        <message>
+            <source>Open</source>
+            <translation>打開</translation>
+        </message>
+        <message>
+            <source>Pin to Top</source>
+            <translation>移到頂部</translation>
+        </message>
+        <message>
+            <source>Move to Top</source>
+            <translation>移至頂部</translation>
+        </message>
+        <message>
+            <source>Remove from favorites</source>
+            <translation>從收藏中移除</translation>
+        </message>
+        <message>
+            <source>Add to favorites</source>
+            <translation>添加到收藏</translation>
+        </message>
+        <message>
+            <source>Remove from desktop</source>
+            <translation>從桌面移除</translation>
+        </message>
+        <message>
+            <source>Send to desktop</source>
+            <translation>傳送到桌面</translation>
+        </message>
+        <message>
+            <source>Remove from dock</source>
+            <translation>從任務欄移除</translation>
+        </message>
+        <message>
+            <source>Send to dock</source>
+            <translation>傳送到任務欄</translation>
+        </message>
+        <message>
+            <source>Remove from startup</source>
+            <translation>從開機啟動中移除</translation>
+        </message>
+        <message>
+            <source>Add to startup</source>
+            <translation>加至開機啟動</translation>
+        </message>
+        <message>
+            <source>Use a proxy</source>
+            <translation>使用代理</translation>
+        </message>
+        <message>
+            <source>Disable display scaling</source>
+            <translation>禁用屏幕縮放</translation>
+        </message>
+        <message>
+            <source>Uninstall</source>
+            <translation>卸載</translation>
+        </message>
+    </context>
+    <context>
+        <name>BottomBar</name>
+        <message>
+            <source>Power</source>
+            <translation>電源</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+        <message>
+            <source>Full-screen Mode</source>
+            <translation>全螢幕模式</translation>
+        </message>
+    </context>
+    <context>
+        <name>DummyAppItemMenu</name>
+        <message>
+            <source>Install</source>
+            <translation>安裝</translation>
+        </message>
+        <message>
+            <source>Remove</source>
+            <translation>移除</translation>
+        </message>
+    </context>
+    <context>
+        <name>FrequentlyUsedView</name>
+        <message>
+            <source>Frequently Used</source>
+            <translation>我的常用</translation>
+        </message>
+    </context>
+    <context>
+        <name>FullscreenFrame</name>
+        <message>
+            <source>Window Mode</source>
+            <translation>窗口模式</translation>
+        </message>
+    </context>
+    <context>
+        <name>Main</name>
+        <message>
+            <source>Internet</source>
+            <translation>網際網路</translation>
+        </message>
+        <message>
+            <source>Chat</source>
+            <translation>社交溝通</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂欣賞</translation>
+        </message>
+        <message>
+            <source>Video</source>
+            <translation>影片播放</translation>
+        </message>
+        <message>
+            <source>Graphics</source>
+            <translation>美工繪圖</translation>
+        </message>
+        <message>
+            <source>Games</source>
+            <translation>遊戲娛樂</translation>
+        </message>
+        <message>
+            <source>Office</source>
+            <translation>文書處理</translation>
+        </message>
+        <message>
+            <source>Reading</source>
+            <translation>閱讀翻譯</translation>
+        </message>
+        <message>
+            <source>Development</source>
+            <translation>程式開發</translation>
+        </message>
+        <message>
+            <source>System</source>
+            <translation>系統管理</translation>
+        </message>
+        <message>
+            <source>Others</source>
+            <translation>其他應用</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to uninstall "%1"?</source>
+            <translation>您確定要卸載“%1”嗎？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確 定</translation>
+        </message>
+    </context>
+    <context>
+        <name>RecentlyInstalledView</name>
+        <message>
+            <source>Recently Installed</source>
+            <translation>最近安裝</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchResultView</name>
+        <message>
+            <source>All Apps</source>
+            <translation>所有應用</translation>
+        </message>
+        <message>
+            <source>No search results</source>
+            <translation>無搜索結果</translation>
+        </message>
+    </context>
+    <context>
+        <name>SideBar</name>
+        <message>
+            <source>Free sorting</source>
+            <translation>自由排序</translation>
+        </message>
+        <message>
+            <source>Sort by category</source>
+            <translation>按分類</translation>
+        </message>
+        <message>
+            <source>Sort by name</source>
+            <translation>按名稱</translation>
+        </message>
+        <message>
+            <source>Sorting Mode</source>
+            <translation>排序模式</translation>
+        </message>
+        <message>
+            <source>Computer</source>
+            <translation>計算機</translation>
+        </message>
+        <message>
+            <source>Pictures</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Documents</source>
+            <translation>文檔</translation>
+        </message>
+        <message>
+            <source>Desktop</source>
+            <translation>桌面</translation>
+        </message>
+        <message>
+            <source>Control Center</source>
+            <translation>控制中心</translation>
+        </message>
+    </context>
+    <context>
+        <name>launcheritem</name>
+        <message>
+            <source>Internet</source>
+            <translation>網絡應用</translation>
+        </message>
+        <message>
+            <source>Chat</source>
+            <translation>社交溝通</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂欣賞</translation>
+        </message>
+        <message>
+            <source>Video</source>
+            <translation>影片播放</translation>
+        </message>
+        <message>
+            <source>Graphics</source>
+            <translation>圖形圖像</translation>
+        </message>
+        <message>
+            <source>Games</source>
+            <translation>遊戲娛樂</translation>
+        </message>
+        <message>
+            <source>Office</source>
+            <translation>辦公學習</translation>
+        </message>
+        <message>
+            <source>Reading</source>
+            <translation>閱讀翻譯</translation>
+        </message>
+        <message>
+            <source>Development</source>
+            <translation>程式開發</translation>
+        </message>
+        <message>
+            <source>System</source>
+            <translation>系統管理</translation>
+        </message>
+        <message>
+            <source>Others</source>
+            <translation>其他應用</translation>
+        </message>
+        <message>
+            <source>launchpad</source>
+            <translation>啓動器</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to uninstall "%1"?</source>
+            <translation>您確定要卸載“%1”嗎？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <source>Uninstall</source>
+            <translation>卸 載</translation>
+        </message>
+    </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
@@ -1,343 +1,282 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
-<context>
-    <name>AppItemMenu</name>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="34"/>
-        <source>Open</source>
-        <translation>開啟</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="46"/>
-        <source>Pin to Top</source>
-        <translation>移到頂部</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="55"/>
-        <source>Move to Top</source>
-        <translation>移至頂部</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
-        <source>Remove from favorites</source>
-        <translation>從收藏中移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="65"/>
-        <source>Add to favorites</source>
-        <translation>添加到收藏</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
-        <source>Remove from desktop</source>
-        <translation>從桌面上移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="80"/>
-        <source>Send to desktop</source>
-        <translation>發送到桌面</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
-        <source>Remove from dock</source>
-        <translation>從任務欄上移除</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="91"/>
-        <source>Send to dock</source>
-        <translation>發送到任務欄</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
-        <source>Remove from startup</source>
-        <translation>取消開機自動啟動</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="103"/>
-        <source>Add to startup</source>
-        <translation>開機自動啟動</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="111"/>
-        <source>Use a proxy</source>
-        <translation>使用代理</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="120"/>
-        <source>Disable display scaling</source>
-        <translation>禁用螢幕縮放</translation>
-    </message>
-    <message>
-        <location filename="../../qml/AppItemMenu.qml" line="127"/>
-        <source>Uninstall</source>
-        <translation>移除</translation>
-    </message>
-</context>
-<context>
-    <name>BottomBar</name>
-    <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="33"/>
-        <source>Power</source>
-        <translation>電源</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="62"/>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/BottomBar.qml" line="109"/>
-        <source>Full-screen Mode</source>
-        <translation>全螢幕模式</translation>
-    </message>
-</context>
-<context>
-    <name>DummyAppItemMenu</name>
-    <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="27"/>
-        <source>Install</source>
-        <translation>安裝</translation>
-    </message>
-    <message>
-        <location filename="../../qml/DummyAppItemMenu.qml" line="34"/>
-        <source>Remove</source>
-        <translation>移除</translation>
-    </message>
-</context>
-<context>
-    <name>FrequentlyUsedView</name>
-    <message>
-        <location filename="../../qml/windowed/FrequentlyUsedView.qml" line="36"/>
-        <source>Frequently Used</source>
-        <translation>我的常用</translation>
-    </message>
-</context>
-<context>
-    <name>FullscreenFrame</name>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="254"/>
-        <source>Window Mode</source>
-        <translation>視窗模式</translation>
-    </message>
-</context>
-<context>
-    <name>Main</name>
-    <message>
-        <location filename="../../qml/Main.qml" line="22"/>
-        <source>Internet</source>
-        <translation>網路應用</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="24"/>
-        <source>Chat</source>
-        <translation>社交溝通</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="26"/>
-        <source>Music</source>
-        <translation>音樂欣賞</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="28"/>
-        <source>Video</source>
-        <translation>影片播放</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="30"/>
-        <source>Graphics</source>
-        <translation>圖形圖像</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="32"/>
-        <source>Games</source>
-        <translation>遊戲娛樂</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="34"/>
-        <source>Office</source>
-        <translation>辦公學習</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="36"/>
-        <source>Reading</source>
-        <translation>閱讀翻譯</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="38"/>
-        <source>Development</source>
-        <translation>編程開發</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="40"/>
-        <source>System</source>
-        <translation>系統管理</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="42"/>
-        <source>Others</source>
-        <translation>其他應用</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="400"/>
-        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation>您確定要移除“%1”嗎？</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="412"/>
-        <source>Cancel</source>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../../qml/Main.qml" line="426"/>
-        <source>Confirm</source>
-        <translation>確 定</translation>
-    </message>
-</context>
-<context>
-    <name>RecentlyInstalledView</name>
-    <message>
-        <location filename="../../qml/windowed/RecentlyInstalledView.qml" line="34"/>
-        <source>Recently Installed</source>
-        <translation>最近安裝</translation>
-    </message>
-</context>
-<context>
-    <name>SearchResultView</name>
-    <message>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="37"/>
-        <source>All Apps</source>
-        <translation>所有應用</translation>
-    </message>
-    <message>
-        <location filename="../../qml/FullscreenFrame.qml" line="557"/>
-        <location filename="../../qml/windowed/SearchResultView.qml" line="102"/>
-        <source>No search results</source>
-        <translation>無搜尋結果</translation>
-    </message>
-</context>
-<context>
-    <name>SideBar</name>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="40"/>
-        <source>Free sorting</source>
-        <translation>自由排序</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="54"/>
-        <source>Sort by category</source>
-        <translation>按分類</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="66"/>
-        <source>Sort by name</source>
-        <translation>按名稱</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="90"/>
-        <source>Sorting Mode</source>
-        <translation>排序模式</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="145"/>
-        <source>Computer</source>
-        <translation>電腦</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="156"/>
-        <source>Pictures</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="167"/>
-        <source>Documents</source>
-        <translation>文件</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="178"/>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <location filename="../../qml/windowed/SideBar.qml" line="189"/>
-        <source>Control Center</source>
-        <translation>控制中心</translation>
-    </message>
-</context>
-<context>
-    <name>launcheritem</name>
-    <message>
-        <location filename="../package/launcheritem.qml" line="111"/>
-        <source>Internet</source>
-        <translation>網路應用</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="113"/>
-        <source>Chat</source>
-        <translation>社交溝通</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="115"/>
-        <source>Music</source>
-        <translation>音樂欣賞</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="117"/>
-        <source>Video</source>
-        <translation>影片播放</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="119"/>
-        <source>Graphics</source>
-        <translation>圖形圖像</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="121"/>
-        <source>Games</source>
-        <translation>遊戲娛樂</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="123"/>
-        <source>Office</source>
-        <translation>辦公學習</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="125"/>
-        <source>Reading</source>
-        <translation>閱讀翻譯</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="127"/>
-        <source>Development</source>
-        <translation>編程開發</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="129"/>
-        <source>System</source>
-        <translation>系統管理</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="131"/>
-        <source>Others</source>
-        <translation>其他應用</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="162"/>
-        <source>launchpad</source>
-        <translation>啓動器</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="309"/>
-        <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation>您確定要移除“%1”嗎？</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="321"/>
-        <source>Cancel</source>
-        <translation>取 消</translation>
-    </message>
-    <message>
-        <location filename="../package/launcheritem.qml" line="335"/>
-        <source>Confirm</source>
-        <translation>確 定</translation>
-    </message>
-</context>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_TW" version="2.1">
+    <context>
+        <name>AppItemMenu</name>
+        <message>
+            <source>Open</source>
+            <translation>開啟</translation>
+        </message>
+        <message>
+            <source>Pin to Top</source>
+            <translation>移到頂部</translation>
+        </message>
+        <message>
+            <source>Move to Top</source>
+            <translation>移至頂部</translation>
+        </message>
+        <message>
+            <source>Remove from favorites</source>
+            <translation>從收藏中移除</translation>
+        </message>
+        <message>
+            <source>Add to favorites</source>
+            <translation>添加到收藏</translation>
+        </message>
+        <message>
+            <source>Remove from desktop</source>
+            <translation>從桌面上移除</translation>
+        </message>
+        <message>
+            <source>Send to desktop</source>
+            <translation>發送到桌面</translation>
+        </message>
+        <message>
+            <source>Remove from dock</source>
+            <translation>從任務欄上移除</translation>
+        </message>
+        <message>
+            <source>Send to dock</source>
+            <translation>發送到任務欄</translation>
+        </message>
+        <message>
+            <source>Remove from startup</source>
+            <translation>取消開機自動啟動</translation>
+        </message>
+        <message>
+            <source>Add to startup</source>
+            <translation>開機自動啟動</translation>
+        </message>
+        <message>
+            <source>Use a proxy</source>
+            <translation>使用代理</translation>
+        </message>
+        <message>
+            <source>Disable display scaling</source>
+            <translation>禁用螢幕縮放</translation>
+        </message>
+        <message>
+            <source>Uninstall</source>
+            <translation>移除</translation>
+        </message>
+    </context>
+    <context>
+        <name>BottomBar</name>
+        <message>
+            <source>Power</source>
+            <translation>電源</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+        <message>
+            <source>Full-screen Mode</source>
+            <translation>全螢幕模式</translation>
+        </message>
+    </context>
+    <context>
+        <name>DummyAppItemMenu</name>
+        <message>
+            <source>Install</source>
+            <translation>安裝</translation>
+        </message>
+        <message>
+            <source>Remove</source>
+            <translation>移除</translation>
+        </message>
+    </context>
+    <context>
+        <name>FrequentlyUsedView</name>
+        <message>
+            <source>Frequently Used</source>
+            <translation>我的常用</translation>
+        </message>
+    </context>
+    <context>
+        <name>FullscreenFrame</name>
+        <message>
+            <source>Window Mode</source>
+            <translation>視窗模式</translation>
+        </message>
+    </context>
+    <context>
+        <name>Main</name>
+        <message>
+            <source>Internet</source>
+            <translation>網路應用</translation>
+        </message>
+        <message>
+            <source>Chat</source>
+            <translation>社交溝通</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂欣賞</translation>
+        </message>
+        <message>
+            <source>Video</source>
+            <translation>影片播放</translation>
+        </message>
+        <message>
+            <source>Graphics</source>
+            <translation>圖形圖像</translation>
+        </message>
+        <message>
+            <source>Games</source>
+            <translation>遊戲娛樂</translation>
+        </message>
+        <message>
+            <source>Office</source>
+            <translation>辦公學習</translation>
+        </message>
+        <message>
+            <source>Reading</source>
+            <translation>閱讀翻譯</translation>
+        </message>
+        <message>
+            <source>Development</source>
+            <translation>編程開發</translation>
+        </message>
+        <message>
+            <source>System</source>
+            <translation>系統管理</translation>
+        </message>
+        <message>
+            <source>Others</source>
+            <translation>其他應用</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to uninstall "%1"?</source>
+            <translation>您確定要移除“%1”嗎？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確 定</translation>
+        </message>
+    </context>
+    <context>
+        <name>RecentlyInstalledView</name>
+        <message>
+            <source>Recently Installed</source>
+            <translation>最近安裝</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchResultView</name>
+        <message>
+            <source>All Apps</source>
+            <translation>所有應用</translation>
+        </message>
+        <message>
+            <source>No search results</source>
+            <translation>無搜尋結果</translation>
+        </message>
+    </context>
+    <context>
+        <name>SideBar</name>
+        <message>
+            <source>Free sorting</source>
+            <translation>自由排序</translation>
+        </message>
+        <message>
+            <source>Sort by category</source>
+            <translation>按分類</translation>
+        </message>
+        <message>
+            <source>Sort by name</source>
+            <translation>按名稱</translation>
+        </message>
+        <message>
+            <source>Sorting Mode</source>
+            <translation>排序模式</translation>
+        </message>
+        <message>
+            <source>Computer</source>
+            <translation>電腦</translation>
+        </message>
+        <message>
+            <source>Pictures</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Documents</source>
+            <translation>文件</translation>
+        </message>
+        <message>
+            <source>Desktop</source>
+            <translation>桌面</translation>
+        </message>
+        <message>
+            <source>Control Center</source>
+            <translation>控制中心</translation>
+        </message>
+    </context>
+    <context>
+        <name>launcheritem</name>
+        <message>
+            <source>Internet</source>
+            <translation>網路應用</translation>
+        </message>
+        <message>
+            <source>Chat</source>
+            <translation>社交溝通</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂欣賞</translation>
+        </message>
+        <message>
+            <source>Video</source>
+            <translation>影片播放</translation>
+        </message>
+        <message>
+            <source>Graphics</source>
+            <translation>圖形圖像</translation>
+        </message>
+        <message>
+            <source>Games</source>
+            <translation>遊戲娛樂</translation>
+        </message>
+        <message>
+            <source>Office</source>
+            <translation>辦公學習</translation>
+        </message>
+        <message>
+            <source>Reading</source>
+            <translation>閱讀翻譯</translation>
+        </message>
+        <message>
+            <source>Development</source>
+            <translation>編程開發</translation>
+        </message>
+        <message>
+            <source>System</source>
+            <translation>系統管理</translation>
+        </message>
+        <message>
+            <source>Others</source>
+            <translation>其他應用</translation>
+        </message>
+        <message>
+            <source>launchpad</source>
+            <translation>啓動器</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to uninstall "%1"?</source>
+            <translation>您確定要移除“%1”嗎？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取 消</translation>
+        </message>
+        <message>
+            <source>Uninstall</source>
+            <translation>卸 載</translation>
+        </message>
+    </context>
 </TS>


### PR DESCRIPTION
as title.

Log:
PMS: BUG-324669

## Summary by Sourcery

Modify the uninstall confirmation dialog to display "Uninstall" instead of "Confirm" and synchronize translation files to reflect this change

Bug Fixes:
- Use a descriptive "Uninstall" button label for the uninstall confirmation dialog instead of the generic "Confirm"

Enhancements:
- Regenerate and standardize translation files across all locales by updating TS headers, removing obsolete metadata, and refreshing entries for the updated label