### PR TITLE
fix: resolve focus loss when switching from fullscreen to windowed

### DIFF
--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -202,3 +202,13 @@ void LauncherController::showHelp()
     message << "dde" << helpTitle;
     QDBusConnection::sessionBus().asyncCall(message);
 }
+
+//首次从全屏切换到窗口时候，会出现焦点丢失抖动问题，从而导致启动器窗口不显示，所以采用此方法处理。
+void LauncherController::setCurrentFrameToWindowedFrame()
+{
+    setVisible(false);
+    QTimer::singleShot(1, this, [this]() {
+        setCurrentFrame("WindowedFrame");
+        setVisible(true);
+    });
+}

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -53,6 +53,7 @@ public:
 
     Q_INVOKABLE void closeAllPopups();
     Q_INVOKABLE void showHelp();
+    Q_INVOKABLE void setCurrentFrameToWindowedFrame();
 
 signals:
     void currentFrameChanged();

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -264,7 +264,7 @@ InputEventItem {
                         }
                         onClicked: {
                             searchEdit.text = ""
-                            LauncherController.currentFrame = "WindowedFrame"
+                            LauncherController.setCurrentFrameToWindowedFrame()
                         }
                     }
 


### PR DESCRIPTION
1. Added new method setCurrentFrameToWindowedFrame() to handle focus loss issue
2. Implemented delayed frame switching with QTimer to prevent window flickering
3. Modified FullscreenFrame.qml to use new method instead of direct property change
4. The fix addresses a bug where launcher window wouldn't show after switching from fullscreen mode due to focus loss

fix: 修复从全屏切换到窗口模式时的焦点丢失问题

1. 新增 setCurrentFrameToWindowedFrame() 方法处理焦点丢失问题
2. 使用 QTimer 实现延迟的框架切换，防止窗口闪烁
3. 修改 FullscreenFrame.qml 使用新方法替代直接属性修改
4. 该修复解决了从全屏模式切换后启动器窗口因焦点丢失无法显示的问题

Pms: BUG-310945

## Summary by Sourcery

Introduce a QTimer-based deferred frame switch to resolve focus loss when toggling from fullscreen to windowed mode

Bug Fixes:
- Fix focus loss and flicker that prevented the launcher window from appearing after switching out of fullscreen

Enhancements:
- Add setCurrentFrameToWindowedFrame method and update FullscreenFrame.qml to invoke it for delayed frame switching