### PR TITLE
fix: improve window transition and drag visibility

### DIFF
--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -207,7 +207,7 @@ void LauncherController::showHelp()
 void LauncherController::setCurrentFrameToWindowedFrame()
 {
     setVisible(false);
-    QTimer::singleShot(1, this, [this]() {
+    QTimer::singleShot(100, this, [this]() {
         setCurrentFrame("WindowedFrame");
         setVisible(true);
     });

--- a/qml/windowed/ItemBackground.qml
+++ b/qml/windowed/ItemBackground.qml
@@ -19,7 +19,13 @@ D.BoxPanel {
     color2: selectValue(background, DS.Style.checkedButton.background, DS.Style.highlightedButton.background2)
     insideBorderColor: null
     outsideBorderColor: null
-    visible: button.checked || button.highlighted || button.visualFocus || control.D.ColorSelector.controlState === D.DTK.PressedState || control.D.ColorSelector.controlState === D.DTK.HoveredState
+    visible: {
+        // 检查是否有正在进行的拖拽操作
+        if (typeof dndItem !== "undefined" && dndItem.currentlyDraggedId !== "") {
+            return false
+        }
+        return button.checked || button.highlighted || button.visualFocus || control.D.ColorSelector.controlState === D.DTK.PressedState || control.D.ColorSelector.controlState === D.DTK.HoveredState
+    }
 
     function selectValue(normal, checked, highlighted) {
         if (button.checked) {


### PR DESCRIPTION
1. Changed QTimer delay from 1ms to 100ms in setCurrentFrameToWindowedFrame to prevent visual glitches during window transition
2. Added drag-and-drop visibility check in ItemBackground.qml to hide background during drag operations
3. The timer adjustment ensures smoother frame switching by allowing proper UI updates
4. The drag visibility change prevents visual artifacts when dragging items over buttons

fix: 改进窗口切换和拖拽可见性

1. 将setCurrentFrameToWindowedFrame中的QTimer延迟从1ms改为100ms，防止窗 口切换时的视觉故障
2. 在ItemBackground.qml中添加拖拽操作可见性检查，在拖拽期间隐藏背景
3. 定时器调整通过允许适当的UI更新来确保更平滑的帧切换
4. 拖拽可见性更改防止了在按钮上拖动项目时的视觉伪影

Pms: BUG-323633

## Summary by Sourcery

Improve window transition smoothness and prevent visual artifacts during drag operations

Bug Fixes:
- Increase QTimer delay from 1ms to 100ms in setCurrentFrameToWindowedFrame to avoid visual glitches during window transitions
- Add drag-and-drop visibility check in ItemBackground.qml to hide item background during dragging and prevent visual artifacts