### PR TITLE
fix: adjust grid view highlight appearance

### DIFF
--- a/qml/windowed/GridViewContainer.qml
+++ b/qml/windowed/GridViewContainer.qml
@@ -102,12 +102,9 @@ FocusScope {
                     visible: gridView.activeFocus
                 }
                 Rectangle {
-                    anchors {
-                        fill: parent
-                        margins: 5
-                    }
+                    anchors.fill: parent
                     radius: 8
-                    color: DTK.themeType === ApplicationHelper.DarkType ? Qt.rgba(1, 1, 1, 0.1) : Qt.rgba(0, 0, 0, 0.1)
+                    color: DTK.themeType === ApplicationHelper.DarkType ? Qt.rgba(1, 1, 1, 0.2) : Qt.rgba(0, 0, 0, 0.15)
                     visible: alwaysShowHighlighted
                 }
             }


### PR DESCRIPTION
1. Removed margins from highlight rectangle to make it fill parent completely
2. Increased highlight opacity for better visibility (0.1 to 0.2 for dark theme, 0.1 to 0.15 for light theme)
3. Simplified anchor binding by removing margins configuration

These changes improve the visual feedback when items are highlighted in the grid view, making the selection state more noticeable while maintaining a clean appearance. The increased opacity helps with accessibility and visual clarity.

fix: 调整网格视图高亮外观

1. 移除高亮矩形的边距使其完全填充父元素
2. 增加高亮透明度以提高可见性（暗色主题从0.1到0.2，亮色主题从0.1到0.15）
3. 通过移除边距配置简化了锚点绑定

这些改动改善了网格视图中项目高亮的视觉反馈，使选中状态更加明显同时保持简
洁外观。增加的透明度有助于提升可访问性和视觉清晰度。
Pms: BUG-327065

## Summary by Sourcery

Adjust grid view highlight to fill its parent, improve visibility by increasing theme-specific opacity, and streamline layout bindings

Bug Fixes:
- Remove margins from the highlight rectangle so it fills the parent container
- Increase highlight opacity for dark (0.1→0.2) and light themes (0.1→0.15)

Enhancements:
- Simplify anchor binding configuration by removing explicit margins