### PR TITLE
fix: add linker options for launchpadcommon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,12 @@ target_link_libraries(launchpadcommon PUBLIC
     treeland-integration
 )
 
+target_link_options(launchpadcommon PRIVATE
+    -Wl,--no-undefined
+    -Wl,--build-id=none
+    -Wl,--sort-section=alignment
+)
+
 install(TARGETS launchpadcommon DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(
     FILES dist/org.deepin.dde.shell.launchpad.appdata.xml


### PR DESCRIPTION
Added linker options to launchpadcommon target to:
1. Enable --no-undefined flag to catch undefined symbols during linking
2. Disable build-id generation to reduce binary size
3. Sort sections by alignment for better memory usage These changes improve build reliability and optimize the resulting binary

fix: 为launchpadcommon添加链接器选项

为launchpadcommon目标添加链接器选项：
1. 启用--no-undefined标志以在链接时捕获未定义符号
2. 禁用build-id生成以减少二进制文件大小
3. 按对齐方式排序节区以获得更好的内存使用 这些更改提高了构建可靠性并优化了生成的二进制文件

## Summary by Sourcery

Build:
- Enable --no-undefined flag, disable build-id generation, and sort sections by alignment for launchpadcommon target to improve build reliability and reduce binary size