### PR TITLE
fix: fix building warnings.

### DIFF
--- a/src/ddeintegration/appmgr.cpp
+++ b/src/ddeintegration/appmgr.cpp
@@ -395,6 +395,7 @@ void AppMgr::initObjectManager()
             });
     connect(m_objectManager, &AppManager1ApplicationObjectManager::InterfacesRemoved, this,
             [this](const QDBusObjectPath &objPath, const QStringList &interfaces) {
+                Q_UNUSED(interfaces)
                 const QString key(objPath.path());
                 qDebug() << "InterfacesRemoved by AM, path:" << key;
                 watchingAppItemRemoved(key);

--- a/src/models/itemarrangementproxymodel.cpp
+++ b/src/models/itemarrangementproxymodel.cpp
@@ -358,7 +358,7 @@ void ItemArrangementProxyModel::onSourceModelChanged()
     for (int i = 0; i < appsCount; i++) {
         QString desktopId(AppsModel::instance().data(AppsModel::instance().index(i, 0), AppItem::DesktopIdRole).toString());
         appDesktopIdSet.insert(desktopId);
-        int folder, page, idx;
+        int folder;
         std::tie(folder, std::ignore, std::ignore) = findItem(desktopId);
         // add all existing ones if they are not already in
         if (folder == -1) {

--- a/src/models/itemspagemodel.cpp
+++ b/src/models/itemspagemodel.cpp
@@ -28,6 +28,7 @@ int ItemsPageModel::rowCount(const QModelIndex &parent) const
 QVariant ItemsPageModel::data(const QModelIndex &index, int role) const
 {
     Q_UNUSED(index)
+    Q_UNUSED(role)
     return QVariant();
 }
 

--- a/src/treelandintegration/personalizationmanager.cpp
+++ b/src/treelandintegration/personalizationmanager.cpp
@@ -87,6 +87,8 @@ PersonalizationManager::~PersonalizationManager()
 // return if the window is "personalized" right away.
 bool PersonalizationManager::personalizeWindow(QWindow * window, PersonalizationManager::BgState state)
 {
+    Q_UNUSED(window)
+    Q_UNUSED(state)
     // temporary do nothing for now, since TreeLand plans to update the related protocol
     return true;
     // return m_dptr ? m_dptr->personalizeWindow(window, state) : true;


### PR DESCRIPTION
as title.

Logs:

## Summary by Sourcery

Silence compiler warnings by marking unused variables and parameters and removing redundant declarations

Enhancements:
- Add Q_UNUSED macros for unused parameters (window, state, interfaces, index, role) in multiple classes to avoid warnings
- Remove unnecessary variable declarations (page, idx) in ItemArrangementProxyModel::onSourceModelChanged