### PR TITLE
fix: update confirmation dialog button text and layout

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -322,7 +322,7 @@ AppletItem {
                 spacing: 10
                 Layout.fillWidth: true
                 Layout.topMargin: 20
-                Layout.bottomMargin: 20
+                Layout.bottomMargin: 10
                 
                 Button {
                     id: cancelButton

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet.ts
@@ -275,7 +275,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Uninstall</source>
+        <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -62,11 +64,11 @@
     <name>BottomBar</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Full-screen Mode</source>
@@ -102,23 +104,23 @@
     <name>Main</name>
     <message>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Games</source>
@@ -126,19 +128,19 @@
     </message>
     <message>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Others</source>
@@ -146,7 +148,7 @@
     </message>
     <message>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -218,23 +220,23 @@
     <name>launcheritem</name>
     <message>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Games</source>
@@ -242,19 +244,19 @@
     </message>
     <message>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Others</source>
@@ -266,15 +268,15 @@
     </message>
     <message>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished"/>
+        <source>Confirm</source>
+        <translation type="unfinished">Təsdiq et</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_bo.ts
@@ -275,8 +275,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished">བཤིག་འདོན།</translation>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>Desinstal·la</translation>
+        <source>Confirm</source>
+        <translation type="unfinished">Confirmeu-ho</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Cancelar</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished"/>
+        <source>Confirm</source>
+        <translation type="unfinished">Confirmar</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Peruuta</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>Poista asennus</translation>
+        <source>Confirm</source>
+        <translation type="unfinished">Vahvista</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Annuler</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished"/>
+        <source>Confirm</source>
+        <translation type="unfinished">Confirmer</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -146,7 +148,7 @@
     </message>
     <message>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -266,15 +268,15 @@
     </message>
     <message>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
         <translation>Mégse</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished"/>
+        <source>Confirm</source>
+        <translation type="unfinished">Megerősítés</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_it.ts
@@ -275,8 +275,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished">Disinstalla</translation>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>キャンセル</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished"/>
+        <source>Confirm</source>
+        <translation type="unfinished">確認</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ko.ts
@@ -275,8 +275,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished">제거</translation>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_nb_NO.ts
@@ -275,8 +275,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished">Avinstaller</translation>
+        <source>Confirm</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Anuluj</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>Odinstaluj</translation>
+        <source>Confirm</source>
+        <translation type="unfinished">Potwierdź</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Cancelar</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>Desinstalar</translation>
+        <source>Confirm</source>
+        <translation type="unfinished">Confirmar</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -11,7 +13,7 @@
     </message>
     <message>
         <source>Move to Top</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove from favorites</source>
@@ -77,7 +79,7 @@
     <name>DummyAppItemMenu</name>
     <message>
         <source>Install</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove</source>
@@ -95,7 +97,7 @@
     <name>FullscreenFrame</name>
     <message>
         <source>Window Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -122,7 +124,7 @@
     </message>
     <message>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Office</source>
@@ -146,7 +148,7 @@
     </message>
     <message>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -218,63 +220,63 @@
     <name>launcheritem</name>
     <message>
         <source>Internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Интернет</translation>
     </message>
     <message>
         <source>Chat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Чат</translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Музыка</translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Видео</translation>
     </message>
     <message>
         <source>Graphics</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Графика</translation>
     </message>
     <message>
         <source>Games</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Office</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Офис</translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Чтение</translation>
     </message>
     <message>
         <source>Development</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Разработка</translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Система</translation>
     </message>
     <message>
         <source>Others</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Прочее</translation>
     </message>
     <message>
         <source>launchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to uninstall &quot;%1&quot;?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation type="unfinished"/>
+        <source>Confirm</source>
+        <translation type="unfinished">Подтвердить</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>Скасувати</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>Вилучити</translation>
+        <source>Confirm</source>
+        <translation type="unfinished">Підтвердити</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>取 消</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>卸 载</translation>
+        <source>Confirm</source>
+        <translation>确 定</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>取 消</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>卸 載</translation>
+        <source>Confirm</source>
+        <translation>確 定</translation>
     </message>
 </context>
 </TS>

--- a/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
+++ b/shell-launcher-applet/translations/org.deepin.ds.dock.launcherapplet_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AppItemMenu</name>
     <message>
@@ -273,8 +275,8 @@
         <translation>取 消</translation>
     </message>
     <message>
-        <source>Uninstall</source>
-        <translation>卸 載</translation>
+        <source>Confirm</source>
+        <translation>確 定</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Changed the confirmation dialog button text from "Uninstall" to "Confirm" across all translation files to better reflect the action being confirmed rather than specifically uninstalling Reduced bottom margin from 20 to 10 in launcheritem.qml for better visual spacing in the dialog layout
Updated multiple translation files with proper XML formatting and consistent translation tags
This change improves user interface consistency and makes the confirmation action more generic for various operations

fix: 更新确认对话框按钮文本和布局

将所有翻译文件中的确认对话框按钮文本从"卸载"改为"确认"，以更好地反映确认
操作而非特定卸载行为
在launcheritem.qml中将底部边距从20减少到10，以改善对话框布局的视觉间距
更新多个翻译文件，采用正确的XML格式和一致的翻译标签
此更改提高了用户界面的一致性，并使确认操作更通用，适用于各种操作

Pms: BUG-324669