### PR TITLE
fix: reset page index on frame change

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -734,8 +734,11 @@ InputEventItem {
                 if (folderGridViewPopup.visible) folderGridViewPopup.close()
                 // reset(remove) keyboard focus
                 baseLayer.focus = true
-                // reset page to the first page
-                listviewPage.setCurrentIndex(0)
+            }
+            function onCurrentFrameChanged() {
+                if (LauncherController.currentFrame === "FullscreenFrame") {
+                    listviewPage.setCurrentIndex(0)
+                }
             }
         }
     }


### PR DESCRIPTION
Added onCurrentFrameChanged handler to reset listviewPage index to 0 when switching to FullscreenFrame
Previously the page reset only occurred on escape key press, but now it also triggers when navigating back to FullscreenFrame This ensures consistent behavior when returning to the fullscreen view from other frames

fix: 在框架切换时重置页面索引

添加 onCurrentFrameChanged 处理程序，在切换到 FullscreenFrame 时将 listviewPage 索引重置为 0
之前页面重置仅在按下 escape 键时发生，现在在导航回 FullscreenFrame 时也
会触发
这确保了从其他框架返回全屏视图时行为的一致性

Pms: BUG-288417

## Summary by Sourcery

Ensure the listviewPage resets to the first page whenever FullscreenFrame becomes active by moving the reset logic into an onCurrentFrameChanged handler

Bug Fixes:
- Reset listviewPage index when switching back to FullscreenFrame instead of only on escape key press

Enhancements:
- Extract page reset logic into a dedicated onCurrentFrameChanged handler