### PR TITLE
fix: adjust WindowedFrame layout width

### DIFF
--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -138,7 +138,7 @@ InputEventItem {
                 }
             }
             Layout.fillHeight: true
-            Layout.preferredWidth: 362
+            Layout.preferredWidth: 365
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
             Layout.leftMargin: Helper.frequentlyUsed.leftMargin
             Layout.rightMargin: Helper.frequentlyUsed.rightMargin


### PR DESCRIPTION
Changed Layout.preferredWidth from 362 to 365 to fix layout alignment issues
This minor width adjustment ensures proper UI element positioning and prevents visual glitches
The change maintains the overall layout structure while improving visual consistency

fix: 调整 WindowedFrame 布局宽度

将 Layout.preferredWidth 从 362 改为 365 以修复布局对齐问题
这个微小的宽度调整确保了 UI 元素的正确位置并防止视觉瑕疵
该更改保持了整体布局结构同时提高了视觉一致性

Pms: BUG-330553

## Summary by Sourcery

Bug Fixes:
- Tweak Layout.preferredWidth from 362 to 365 in WindowedFrame.qml to resolve UI alignment glitches