### PR TITLE
fix: improve focus management in folder grid view

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -250,6 +250,13 @@ Popup {
                         anchors.fill: parent
 
                         currentIndex: folderPageIndicator.currentIndex
+                        activeFocusOnTab: false
+                        
+                        // 处理页面切换时的焦点传递
+                        onCurrentIndexChanged: {
+                            if (currentItem)
+                                currentItem.resetCurrentIndex()
+                        }
 
                         Connections {
                             target: ItemArrangementProxyModel
@@ -268,9 +275,21 @@ Popup {
                                 id: folderGridViewLoader
                                 objectName: "Folder GridView Loader"
 
+                                function resetCurrentIndex() {
+                                    if (item && item.resetGridFocus)
+                                        item.resetGridFocus()
+                                }
+
                                 sourceComponent: Rectangle {
                                     anchors.fill: parent
                                     color: "transparent"
+                                    
+                                    function resetGridFocus() {
+                                        if (gridViewContainerLoader && gridViewContainerLoader.item) {
+                                            gridViewContainerLoader.item.currentIndex = 0
+                                            gridViewContainerLoader.item.forceActiveFocus()
+                                        } 
+                                    }
 
                                     MultipageSortFilterProxyModel {
                                         id: folderProxyModel
@@ -320,6 +339,11 @@ Popup {
                                             gridViewClip: false // TODO it maybe a bug for dtk, https://github.com/linuxdeepin/developer-center/issues/8468
                                             activeGridViewFocusOnTab: folderGridViewLoader.SwipeView.isCurrentItem
                                             itemMove: parent.itemMove
+                                            onActiveFocusChanged: {
+                                                if (activeFocus) {
+                                                    currentIndex = 0
+                                                }
+                                            }
                                             delegate: DelegateDropArea {
                                                 width: folderGridViewContainer.cellWidth
                                                 height: folderGridViewContainer.cellHeight
@@ -343,6 +367,12 @@ Popup {
                                             gridViewClip: false
                                             activeGridViewFocusOnTab: folderGridViewLoader.SwipeView.isCurrentItem
                                             itemMove: parent.itemMove
+
+                                            onActiveFocusChanged: {
+                                                if (activeFocus) {
+                                                    currentIndex = 0
+                                                }
+                                            }
                                             delegate: DelegateDropArea {
                                                 width: folderGridViewContainer.cellWidth
                                                 height: folderGridViewContainer.cellHeight


### PR DESCRIPTION
1. Added activeFocusOnTab: false to prevent unwanted tab focus on SwipeView
2. Implemented onCurrentIndexChanged handler to properly transfer focus to grid view when switching pages
3. Added objectName to gridViewContainerLoader for reliable identification in focus logic
4. Added onActiveFocusChanged handlers to reset currentIndex to 0 when grid views gain focus
5. This ensures consistent focus behavior and prevents focus issues when navigating between pages

fix: 改进文件夹网格视图的焦点管理

1. 添加 activeFocusOnTab: false 防止 SwipeView 上出现不需要的标签焦点
2. 实现 onCurrentIndexChanged 处理程序，在切换页面时正确将焦点传递到网格 视图
3. 为 gridViewContainerLoader 添加 objectName 以便在焦点逻辑中可靠识别
4. 添加 onActiveFocusChanged 处理程序，在网格视图获得焦点时将 currentIndex 重置为 0
5. 确保一致的焦点行为，防止在页面间导航时出现焦点问题

Pms: BUG-296091

## Summary by Sourcery

Improve focus management in the folder grid view popup by disabling default tab focus on SwipeView, transferring focus to grid views on page changes, and resetting their indices when they gain focus.

Bug Fixes:
- Fix inconsistent focus behavior when navigating between folder grid pages

Enhancements:
- Disable unwanted tab focus on SwipeView in folder grid popup
- Transfer focus to the current grid view when switching pages via onCurrentIndexChanged handler
- Assign an objectName to the grid view container loader for reliable focus target lookup
- Reset grid view currentIndex to 0 on gaining focus using onActiveFocusChanged handlers