### PR TITLE
chore: bump version to 2.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-launchpad (2.0.11) unstable; urgency=medium
+
+  * fix: improve focus management in folder grid view
+
+ -- wujiangyu <wujiangyu@uniontech.com>  Thu, 04 Sep 2025 17:34:40 +0800
+
 dde-launchpad (2.0.10) unstable; urgency=medium
 
   * feat: add logs with dlogcover.


### PR DESCRIPTION
update changelog to 2.0.11

## Summary by Sourcery

Chores:
- Update debian/changelog to version 2.0.11