### PR TITLE
fix: add right margin to windowed frame layout

### DIFF
--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -111,6 +111,7 @@ InputEventItem {
         anchors.bottom: bottomBar.top
         anchors.topMargin: 10
         anchors.leftMargin: 10
+        anchors.rightMargin: 1
         spacing: 0
         Behavior on opacity {
             NumberAnimation { duration: 200; easing.type: Easing.OutQuad }


### PR DESCRIPTION
Added right margin of 1 pixel to the left panel in WindowedFrame.qml to prevent content from touching the right edge of the panel. This improves visual spacing and prevents potential UI clipping issues when content extends too far to the right.

The change ensures proper visual hierarchy and spacing consistency with other margins already present (topMargin: 10, leftMargin: 10). The small 1px margin provides just enough breathing room without significantly affecting the layout.

Influence:
1. Verify left panel content no longer touches the right edge
2. Check that all UI elements maintain proper spacing
3. Test with different content lengths to ensure no clipping occurs
4. Confirm layout remains consistent across different window sizes

fix: 为窗口化框架布局添加右边距

在WindowedFrame.qml的左面板中添加了1像素的右边距，防止内容接触到面板的右
边缘。这改善了视觉间距，并避免了内容向右延伸过远时可能出现的UI裁剪问题。

此更改确保了视觉层次结构的正确性和与其他已有边距（上边距：10，左边距：
10）的间距一致性。1像素的小边距提供了足够的呼吸空间，而不会显著影响
布局。

Influence:
1. 验证左面板内容不再接触右边缘
2. 检查所有UI元素是否保持适当的间距
3. 使用不同长度的内容测试，确保不会发生裁剪
4. 确认在不同窗口大小下布局保持一致

PMS: BUG-332529

## Summary by Sourcery

Bug Fixes:
- Prevent left panel content in WindowedFrame.qml from touching the right edge by adding a 1px right margin