### PR TITLE
feat: add icon scaling with keyboard shortcuts

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -232,6 +232,7 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
     , m_appWizIntegration(new AppWiz(this))
     , m_dockIntegration(new DdeDock(this))
     , m_appearanceIntegration(new Appearance(this))
+    , m_iconScaleFactor(1.0)
 {
     qCDebug(logDesktopIntegration) << "Initializing DesktopIntegration";
     QScopedPointer<DConfig> dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
@@ -254,6 +255,9 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
     };
     m_compulsoryAppIdList = dconfig->value("compulsoryAppIdList", defaultCompulsoryAppIdList).toStringList();
     qCInfo(logDesktopIntegration) << "Compulsory apps loaded:" << m_compulsoryAppIdList.size() << "apps";
+    
+    m_iconScaleFactor = dconfig->value("iconScaleFactor", 1.0).toReal();
+    qCInfo(logDesktopIntegration) << "Icon scale factor loaded:" << m_iconScaleFactor;
 
     connect(m_dockIntegration, &DdeDock::directionChanged, this, &DesktopIntegration::dockPositionChanged);
     connect(m_dockIntegration, &DdeDock::geometryChanged, this, &DesktopIntegration::dockGeometryChanged);
@@ -269,4 +273,27 @@ double DesktopIntegration::scaleFactor() const
 qreal DesktopIntegration::opacity() const
 {
     return m_appearanceIntegration->opacity();
+}
+
+qreal DesktopIntegration::iconScaleFactor() const
+{
+    return m_iconScaleFactor;
+}
+
+void DesktopIntegration::setIconScaleFactor(qreal factor)
+{
+    if (qFuzzyCompare(m_iconScaleFactor, factor)) {
+        return;
+    }
+    
+    m_iconScaleFactor = factor;
+    
+    // 保存到 dconfig
+    QScopedPointer<DConfig> dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
+    if (dconfig->isValid()) {
+        dconfig->setValue("iconScaleFactor", factor);
+        qCInfo(logDesktopIntegration) << "Icon scale factor saved:" << factor;
+    }
+    
+    emit iconScaleFactorChanged();
 }

--- a/desktopintegration.h
+++ b/desktopintegration.h
@@ -22,6 +22,7 @@ class DesktopIntegration : public QObject
     Q_PROPERTY(QString backgroundUrl READ backgroundUrl NOTIFY backgroundUrlChanged)
     Q_PROPERTY(qreal opacity READ opacity NOTIFY opacityChanged FINAL)
     Q_PROPERTY(double scaleFactor READ scaleFactor NOTIFY scaleFactorChanged FINAL)
+    Q_PROPERTY(qreal iconScaleFactor READ iconScaleFactor WRITE setIconScaleFactor NOTIFY iconScaleFactorChanged FINAL)
 
     QML_NAMED_ELEMENT(DesktopIntegration)
     QML_SINGLETON
@@ -69,6 +70,8 @@ public:
     Q_INVOKABLE void uninstallApp(const QString & desktopId);
     Q_INVOKABLE double scaleFactor() const;
     qreal opacity() const;
+    qreal iconScaleFactor() const;
+    void setIconScaleFactor(qreal factor);
 
 signals:
     void dockPositionChanged();
@@ -77,6 +80,7 @@ signals:
     void backgroundUrlChanged();
     void opacityChanged();
     void scaleFactorChanged();
+    void iconScaleFactorChanged();
 
 private:
     explicit DesktopIntegration(QObject * parent = nullptr);
@@ -85,4 +89,5 @@ private:
     AppWiz * m_appWizIntegration;
     DdeDock * m_dockIntegration;
     Appearance * m_appearanceIntegration;
+    qreal m_iconScaleFactor;
 };

--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -67,12 +67,41 @@ InputEventItem {
         anchors.fill: parent
         focus: true
         objectName: "FullscreenFrame-BaseLayer"
+        
+        property real iconScaleFactor: DesktopIntegration.iconScaleFactor
+        
+        Behavior on iconScaleFactor {
+            NumberAnimation {
+                duration: 200
+                easing.type: Easing.OutQuad
+            }
+        }
 
         Shortcut {
             context: Qt.ApplicationShortcut
             sequences: [StandardKey.HelpContents, "F1"]
             onActivated: LauncherController.showHelp()
             onActivatedAmbiguously: LauncherController.showHelp()
+        }
+
+        Shortcut {
+            context: Qt.ApplicationShortcut
+            sequences: ["Ctrl++", "Ctrl+="]
+            onActivated: {
+                if (DesktopIntegration.iconScaleFactor < 1.0) {
+                    DesktopIntegration.iconScaleFactor = Math.min(DesktopIntegration.iconScaleFactor + 0.1, 1.0)
+                }
+            }
+        }
+
+        Shortcut {
+            context: Qt.ApplicationShortcut
+            sequences: ["Ctrl+-"]
+            onActivated: {
+                if (DesktopIntegration.iconScaleFactor > 0.5) {
+                    DesktopIntegration.iconScaleFactor = Math.max(DesktopIntegration.iconScaleFactor - 0.1, 0.5)
+                }
+            }
         }
 
         readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
@@ -490,6 +519,8 @@ InputEventItem {
                                     visible: dndItem.currentlyDraggedId !== model.desktopId
                                     iconSource: (iconName && iconName !== "") ? iconName : "application-x-desktop"
                                     icons: folderIcons
+                                    iconScaleFactor: baseLayer.iconScaleFactor
+                                    transformOrigin: Item.Center
                                     onItemClicked: {
                                         launchApp(desktopId)
                                     }
@@ -562,6 +593,8 @@ InputEventItem {
                         width: searchResultGridViewContainer.cellWidth
                         height: searchResultGridViewContainer.cellHeight
                         padding: 5
+                        iconScaleFactor: baseLayer.iconScaleFactor
+                        transformOrigin: Item.Center
                         onItemClicked: {
                             launchApp(desktopId)
                         }

--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -30,6 +30,7 @@ Control {
     property bool dndEnabled: false
     readonly property bool isWindowedMode: LauncherController.currentFrame === "WindowedFrame"
     property alias displayFont: iconItemLabel.font
+    property real iconScaleFactor: 1.0
 
     Accessible.name: iconItemLabel.text
 
@@ -144,7 +145,7 @@ Control {
 
                                     name: modelData
                                     sourceSize: Qt.size(root.maxIconSizeInFolder, root.maxIconSizeInFolder)
-                                    scale: parent.width / 2 / root.maxIconSizeInFolder
+                                    scale: (parent.width / 2 / root.maxIconSizeInFolder) * root.iconScaleFactor
                                     palette: DTK.makeIconPalette(root.palette)
                                     theme: ApplicationHelper.DarkType
                                 }
@@ -174,7 +175,7 @@ Control {
                         anchors.fill: parent
                         name: iconSource
                         sourceSize: Qt.size(root.maxIconSize, root.maxIconSize)
-                        scale: parent.width / root.maxIconSize
+                        scale: (parent.width / root.maxIconSize) * root.iconScaleFactor
                         palette: DTK.makeIconPalette(root.palette)
                         theme: ApplicationHelper.DarkType
                     }

--- a/src/models/org.deepin.ds.launchpad.json
+++ b/src/models/org.deepin.ds.launchpad.json
@@ -86,6 +86,17 @@
       "description[zh_CN]": "在搜索时候是否允许搜索Desktop ID。",
       "permissions": "readwrite",
       "visibility": "public"
+    },
+    "iconScaleFactor": {
+      "value": 1.0,
+      "serial": 0,
+      "flags": [],
+      "name": "Icon Scale Factor",
+      "name[zh_CN]": "图标缩放比例",
+      "description": "The scale factor for application icons in fullscreen mode.",
+      "description[zh_CN]": "全屏模式下应用图标的缩放比例。",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }


### PR DESCRIPTION
1. Added icon scaling functionality with Ctrl++/Ctrl+= to zoom in and Ctrl+- to zoom out
2. Implemented smooth scaling animation with 200ms duration and easing
3. Set scaling limits between 0.5x and 1.0x with 0.1x step increments
4. Updated IconItemDelegate to support iconScaleFactor property for consistent scaling
5. Added transformOrigin: Item.Center to maintain icon positioning during scaling

feat: 添加图标缩放功能和键盘快捷键

1. 添加图标缩放功能，支持 Ctrl++/Ctrl+= 放大和 Ctrl+- 缩小
2. 实现平滑缩放动画，持续时间为200毫秒并带有缓动效果
3. 设置缩放限制在0.5倍到1.0倍之间，每次调整0.1倍
4. 更新IconItemDelegate以支持iconScaleFactor属性，确保缩放一致性
5. 添加transformOrigin: Item.Center以在缩放过程中保持图标定位

Pms: BUG-289529

## Summary by Sourcery

Introduce interactive icon scaling with keyboard zoom shortcuts, animated transitions, and consistent delegate support

New Features:
- Add keyboard shortcuts (Ctrl++/Ctrl+= to zoom in and Ctrl+- to zoom out) for icon scaling
- Implement smooth icon scaling animation with 200ms duration and easing
- Enforce scaling limits between 0.5x and 1.0x with 0.1x increments

Enhancements:
- Expose iconScaleFactor in IconItemDelegate and apply it to icon rendering
- Set transform origin to center to preserve icon positioning during scaling