### PR TITLE
fix: remove category check from resetViewState

### DIFF
--- a/qml/windowed/AppList.qml
+++ b/qml/windowed/AppList.qml
@@ -26,9 +26,7 @@ ColumnLayout {
     }
 
     function resetViewState() {
-        if (CategorizedSortProxyModel.categoryType !== CategorizedSortProxyModel.FreeCategory) {
-            loader.item.resetViewState()
-        }
+        loader.item.resetViewState()
     }
 
     function switchToFreeSort(freeSort) {

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -39,6 +39,10 @@ Item {
         listView.positionViewAtBeginning()
     }
 
+    function resetViewState() {
+        positionViewAtBeginning()
+    }
+
     ListView {
         id: listView
         anchors.fill: parent


### PR DESCRIPTION
1. Removed conditional check for FreeCategory in AppList.qml's resetViewState function
2. Added resetViewState implementation to FreeSortListView.qml that calls positionViewAtBeginning
3. Now resetViewState works consistently across all category types
4. Previously resetViewState was only working for non-FreeCategory views

fix: 从 resetViewState 中移除类别检查

1. 移除了 AppList.qml 中 resetViewState 函数对 FreeCategory 的条件检查
2. 在 FreeSortListView.qml 中添加了 resetViewState 实现，调用 positionViewAtBeginning
3. 现在 resetViewState 在所有类别类型中都能一致工作
4. 之前 resetViewState 仅对非 FreeCategory 视图有效

Pms: BUG-335941

## Summary by Sourcery

Bug Fixes:
- Fix resetViewState to work for FreeCategory by removing the categoryType check in AppList.qml and adding a resetViewState implementation in FreeSortListView.qml.