### PR TITLE
chore: update changelog to 2.0.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-launchpad (2.0.34) unstable; urgency=medium
+
+  * fix: increase flickable cache buffer for better performance
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 09 Apr 2026 20:29:10 +0800
+
 dde-launchpad (2.0.33) unstable; urgency=medium
 
   * feat: set window title for launcher popup


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.34

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.34
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.34 targeting master.