### PR TITLE
fix: use positionViewAtBeginning instead of set contentY

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -24,7 +24,7 @@ FocusScope {
         let wasFollowing = listView.highlightFollowsCurrentItem
         listView.highlightFollowsCurrentItem = false
         listView.currentIndex = 0
-        listView.contentY = 0
+        listView.positionViewAtBeginning()
         listView.highlightFollowsCurrentItem = wasFollowing
         if (!LauncherController.visible) {
             alphabetCategoryPopup.close()


### PR DESCRIPTION
It is not recommended to use contentX or contentY to position the view at a particular index. This is unreliable since removing items from the start of the list does not cause all other items to be repositioned, and because the actual start of the view can vary based on the size of the delegates.

PMS: BUG-356795

## Summary by Sourcery

Bug Fixes:
- Use positionViewAtBeginning() to reliably scroll the app list to the top instead of setting contentY to 0.