### PR TITLE
fix: align folder popup to physical pixels for sharp 1px borders

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DStyle
 
@@ -53,8 +54,11 @@ Popup {
     // TODO: 经验证发现：Poppu窗口高度为奇数时，会多显示一个像素的外边框；为偶数时不会显示
     // 因此，这里需要保证高度是偶数来确保Popup窗口没有外边框
     height: ((cs * 3) % 2 === 0 ? (cs * 3) : (cs * 3 + 1)) + 130 /* title height*/
-    x: centerPosition.x - (width / 2)
-    y: centerPosition.y - (height / 2)
+    // 获取当前屏幕的 DPR，用于物理像素对齐
+    property real dpr: Screen.devicePixelRatio
+
+    x: Math.round((centerPosition.x - (width / 2)) * dpr) / dpr
+    y: Math.round((centerPosition.y - (height / 2)) * dpr) / dpr
 
     onClosed: {
         // reset folder view

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -192,8 +192,9 @@ InputEventItem {
 
     FolderGridViewPopup {
         id: folderGridViewPopup
-        width: 370
-        height: 330
+        // 物理像素对齐，确保在各种缩放比例下边缘都能对齐到整数物理像素
+        width: Math.round(370 * Screen.devicePixelRatio) / Screen.devicePixelRatio
+        height: Math.round(330 * Screen.devicePixelRatio) / Screen.devicePixelRatio
         folderNameFont: LauncherController.adjustFontWeight(DTK.fontManager.t6, Font.Bold)
         centerPosition: Qt.point(curPointX, curPointY)
 


### PR DESCRIPTION
Apply pixel snapping to FolderGridViewPopup's position (x, y) and dimensions (width, height) to ensure edges align with physical pixel boundaries. This fixes blurry/anti-aliased 1px borders at fractional scaling factors like 125% or 150%.

修复：应用组弹窗物理像素对齐以获得锐利的1px描边

对 FolderGridViewPopup 的位置 (x, y) 和尺寸 (width, height) 应用 物理像素对齐，确保边缘与物理像素边界对齐。这修复了在 125% 或
150% 等非整数缩放比例下 1px 描边模糊/抗锯齿的问题。

PMS: BUG-306847

## Summary by Sourcery

Bug Fixes:
- Snap FolderGridViewPopup position and size to physical pixels to fix blurred 1px borders on non-integer scale factors.