### PR TITLE
fix: temporarily disable flickable bounds behavior

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -384,7 +384,6 @@ InputEventItem {
                     highlightFollowsCurrentItem: true
                     highlightMoveDuration: 200
                     highlightMoveVelocity: -1
-                    boundsBehavior: Flickable.StopAtBounds
                     cacheBuffer: width * 2
 
                     activeFocusOnTab: true


### PR DESCRIPTION
1. Commented out the boundsBehavior property setting in the GridView
2. This change disables the "StopAtBounds" behavior that was preventing scrolling beyond content boundaries
3. The property is temporarily disabled for testing purposes or to allow smoother scrolling behavior

Influence:
1. Test scrolling behavior in the GridView to ensure it can scroll beyond content boundaries
2. Verify that the UI remains responsive and doesn't exhibit unexpected behavior
3. Check if any other scrolling-related properties need adjustment
4. Test with different content sizes to ensure proper functionality
5. Monitor performance impact of removing bounds constraints

fix: 临时禁用可滑动组件的边界行为

1. 注释掉了 GridView 中的 boundsBehavior 属性设置
2. 此更改禁用了阻止滚动超出内容边界的 "StopAtBounds" 行为
3. 暂时禁用此属性用于测试目的或实现更平滑的滚动行为

Influence:
1. 测试 GridView 中的滚动行为，确保可以滚动超出内容边界
2. 验证 UI 保持响应且不会出现意外行为
3. 检查是否需要调整其他与滚动相关的属性
4. 使用不同大小的内容进行测试以确保功能正常
5. 监控移除边界约束对性能的影响

PMS: BUG-356899

BUG-343525 修改后未复现，后续提BUG继续追踪。