### PR TITLE
style: adjust page indicator dot size in fullscreen mode

### DIFF
--- a/qml/FolderGridViewPopup.qml
+++ b/qml/FolderGridViewPopup.qml
@@ -692,8 +692,8 @@ Popup {
                     spacing: isWindowedMode ? 5 : 10
 
                     delegate: Rectangle {
-                        implicitWidth: isWindowedMode ? 5 : 10
-                        implicitHeight: isWindowedMode ? 5 : 10
+                        implicitWidth: isWindowedMode ? 5 : 8
+                        implicitHeight: isWindowedMode ? 5 : 8
 
                         radius: width / 2
                         color: Qt.rgba(255, 255, 255, index === folderPageIndicator.currentIndex ? 0.9 : pressed ? 0.5 : 0.2)


### PR DESCRIPTION
Changed the implicit width and height of page indicator dots from 10 to 8 pixels when not in windowed mode (i.e., in fullscreen mode). This reduces the visual size of the navigation dots slightly to create a more balanced and less intrusive appearance during fullscreen folder browsing.

The adjustment maintains the windowed mode size at 5 pixels while optimizing the fullscreen experience with slightly smaller dots that are still clearly visible but less dominant in the UI.

Log: Adjusted page indicator dot size in fullscreen folder view for better visual balance

Influence:
1. Test folder navigation in both windowed and fullscreen modes
2. Verify page indicator dots are visible and correctly sized in each mode
3. Check that the current page indicator remains clearly distinguishable
4. Ensure touch/click targets remain accessible
5. Verify visual consistency across different screen resolutions
6. Test with various folder content and page counts

style: 调整全屏模式下的页面指示点大小

将非窗口模式（即全屏模式）下的页面指示点的隐式宽度和高度从10像素调整为8
像素。这略微减小了导航点的视觉尺寸，在全屏文件夹浏览时创建更平衡且不那么
突兀的外观。

此调整保持窗口模式下的尺寸为5像素，同时通过略微减小但仍清晰可见的指示点
来优化全屏体验，使其在UI中不那么显眼。

Log: 调整全屏文件夹视图中的页面指示点大小以获得更好的视觉平衡

Influence:
1. 测试窗口模式和全屏模式下的文件夹导航
2. 验证页面指示点在每种模式下是否可见且尺寸正确
3. 检查当前页面指示器是否保持清晰可辨
4. 确保触摸/点击目标保持可访问性
5. 验证不同屏幕分辨率下的视觉一致性
6. 测试各种文件夹内容和页面数量

PMS: BUG-356945

## Summary by Sourcery

Enhancements:
- Reduce fullscreen page indicator dot size in FolderGridViewPopup to make navigation dots less visually dominant without affecting windowed mode behavior.