### PR TITLE
chore: update changelog to 2.0.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-launchpad (2.0.35) unstable; urgency=medium
+
+  * style: adjust page indicator dot size in fullscreen mode
+  * fix: temporarily disable flickable bounds behavior
+  * fix: align folder popup to physical pixels for sharp 1px borders
+  * fix: use positionViewAtBeginning instead of set contentY
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:17 +0800
+
 dde-launchpad (2.0.34) unstable; urgency=medium
 
   * fix: increase flickable cache buffer for better performance


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.35

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.35
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to document version 2.0.35.