### PR TITLE
feat: complete launchpad logging integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -29,6 +29,15 @@ find_package(${ASQT_NS} 1.0 REQUIRED)
 find_package(ECM NO_MODULE)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
   find_package(Qt6 COMPONENTS GuiPrivate REQUIRED)
+endif()
+
+# Check if dde-api provides EventLogger (header-only)
+find_package(DDEAPI QUIET)
+if(DDEAPI_FOUND)
+    set(HAVE_DDE_API_EVENTLOGGER ON)
+    message(STATUS "Found DDEAPI: EventLogger available")
+else()
+    message(STATUS "DDEAPI not found, event logging will be disabled")
 endif()
 
 set_package_properties(${ASQT_NS} PROPERTIES
@@ -139,6 +148,11 @@ target_link_libraries(launchpadcommon PUBLIC
     dde-integration-dbus
     treeland-integration
 )
+
+if (HAVE_DDE_API_EVENTLOGGER)
+    target_compile_definitions(launchpadcommon PRIVATE HAVE_DDE_API_EVENTLOGGER)
+    target_link_libraries(launchpadcommon PRIVATE DDEAPI::EventLogger)
+endif()
 
 install(TARGETS launchpadcommon DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Build-Depends:
 # v-- provides DHiDPIHelper
  libdtk6gui-dev (>= 6.0.19),
  libdtk6declarative-dev (>> 6.7.33),
+ dde-api-dev (>> 6.0.39),
  libdde-shell-dev (>= 0.0.10),
  libappstreamqt-dev (>= 1.0.0)
 Standards-Version: 4.6.0

--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,12 +15,29 @@
 #include <QDBusConnection>
 #include <QLoggingCategory>
 
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+#endif
+
 #include <private/qguiapplication_p.h>
 
 DGUI_USE_NAMESPACE
 
 namespace {
 Q_LOGGING_CATEGORY(logController, "org.deepin.dde.launchpad.controller")
+
+constexpr qint64 EVENT_LOGGER_LAUNCHPAD_MODE = 1000610012;
+
+void logLaunchpadMode(const QString &mode, const char *description)
+{
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_LAUNCHPAD_MODE, QStringLiteral("launchpad_config"), {
+            {QStringLiteral("launchpad_mode"), mode}
+        }));
+#endif
+    qCInfo(logController) << "EventLogger: launchpad mode" << description << ":" << mode;
+}
 }
 
 LauncherController::LauncherController(QObject *parent)
@@ -38,6 +55,8 @@ LauncherController::LauncherController(QObject *parent)
 
     m_currentFrame = settings.value("current_frame", "WindowedFrame").toString();
     qCInfo(logController) << "Current frame mode:" << m_currentFrame;
+
+    logLaunchpadMode(m_currentFrame, "on startup");
 
     // Interval set to 500=>1000ms for issue https://github.com/linuxdeepin/developer-center/issues/8137
     m_timer->setInterval(1000);
@@ -151,6 +170,9 @@ void LauncherController::setCurrentFrame(const QString &frame)
 
     m_currentFrame = frame;
     qDebug() << "set current frame:" << m_currentFrame;
+
+    logLaunchpadMode(m_currentFrame, "changed to");
+
     m_pendingHide = false;
     m_timer->start();
     emit currentFrameChanged();


### PR DESCRIPTION
Add optional dde-api detection and Debian build dependency updates, and finish launchpad-side logging support in the shared launcher controller. Keep the launchpad build configuration and packaging aligned with the new logging integration.

feat: 完善启动器日志集成

增加可选 dde-api 检测与 Debian 构建依赖更新，并在共享启动器控制器中补全启动器侧日志支持。 同步更新启动器的构建配置与打包依赖，使新的日志集成能够正确构建和交付。

PMS: TASK-388657

## Summary by Sourcery

Integrate optional dde-api based event logging for launchpad mode and wire it into the shared launcher controller while updating build configuration accordingly.

New Features:
- Add launchpad mode event logging via dde-api EventLogger on startup and when the frame mode changes.

Enhancements:
- Update launcher controller copyright years to cover 2023–2026.

Build:
- Detect optional dde-api eventlogger headers in CMake and conditionally enable related compilation flags for the launchpad common library.