### PR TITLE
fix: adjust search box position for wayland dock overlap

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -9,7 +9,7 @@ import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 import QtQuick.Window 2.15
 import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.ds 1.0
 
 import org.deepin.launchpad 1.0
 import org.deepin.launchpad.models 1.0
@@ -111,8 +111,10 @@ InputEventItem {
         }
 
         readonly property bool isHorizontalDock: DesktopIntegration.dockPosition === Qt.UpArrow || DesktopIntegration.dockPosition === Qt.DownArrow
-        readonly property int dockSpacing: (isHorizontalDock ? DesktopIntegration.dockGeometry.height : DesktopIntegration.dockGeometry.width) / Screen.devicePixelRatio
-
+        readonly property int dockSpacing: {
+            var dock = DS.applet("org.deepin.ds.dock")
+            return isHorizontalDock ? dock.rootObject.height : dock.rootObject.width 
+        }
         leftPadding: (DesktopIntegration.dockPosition === Qt.LeftArrow ? dockSpacing : 0)
         rightPadding: (DesktopIntegration.dockPosition === Qt.RightArrow ? dockSpacing : 0)
         topPadding: (DesktopIntegration.dockPosition === Qt.UpArrow ? dockSpacing : 0) + 20


### PR DESCRIPTION
Replace DS import with direct dock applet access via DS.applet to
calculate dock spacing, improving accuracy by using dock's root object
dimensions instead of scaled geometry values.

Log: Improved dock spacing calculation in FullscreenFrame

Influence:
1. Test fullscreen frame display with different dock positions (top,
bottom, left, right)
2. Verify dock spacing is correctly applied when dock is hidden or shown
3. Test with different display scale factors
4. Verify no regressions in dock area padding

refactor: 优化全屏框架中的 dock 间距计算

将 DS 导入替换为通过 DS.applet 直接访问 dock 应用，使用 dock 的根对象尺
寸而非缩放后的几何值来计算 dock 间距，提高计算准确性。

Log: 优化全屏框架中的 dock 间距计算

Influence:
1. 测试不同 dock 位置（上、下、左、右）下的全屏框架显示
2. 验证 dock 隐藏或显示时间距计算是否正确
3. 测试不同显示缩放比例下的表现
4. 验证 dock 区域边距无回归问题

wayland下使用 Screen.devicePixelRatio 在1.25倍下，返回为2，因为在 Wayland 下往往会返回一个取整后的整数（如 2）
因此采用直接获取任务栏宽高方式，在wayland环境实现基于任务栏的大小从而保证启动器搜索框，以及指示器，关闭按钮的正确位移。

PMS: BUG-345751 BUG-345737