### PR TITLE
fix: allow right-click long press to trigger context menu on touchscreen

### DIFF
--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -158,7 +158,7 @@ Control {
                         }
                         // touchscreen long press.
                         onPressAndHold: function (mouse) {
-                            if (mouse.button === Qt.NoButton) {
+                            if (mouse.button === Qt.NoButton ||| mouse.button === Qt.RightButton) {
                                 root.menuTriggered()
                             }
                         }

--- a/qml/IconItemDelegate.qml
+++ b/qml/IconItemDelegate.qml
@@ -118,7 +118,21 @@ Control {
                         hoverEnabled: false
                         drag.target: root.dndEnabled ? root : null
                         drag.threshold: 1
+
+                        // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
+                        property bool isTouchLongPressed: false
+
+                        TapHandler {
+                            acceptedDevices: PointerDevice.TouchScreen
+                            gesturePolicy: TapHandler.DragThreshold
+                            onLongPressed: {
+                                mouseArea.isTouchLongPressed = true
+                                root.menuTriggered()
+                            }
+                        }
+
                         onPressed: function (mouse) {
+                            isTouchLongPressed = false
                             if (mouse.button === Qt.LeftButton && root.dndEnabled) {
                                 root.Drag.hotSpot = mapToItem(iconLoader, Qt.point(mouse.x, mouse.y))
                                 iconLoader.grabToImage(function(result) {
@@ -146,6 +160,11 @@ Control {
                             }
                         }
                         onClicked: function(mouse) {
+                            if (isTouchLongPressed) {
+                                isTouchLongPressed = false
+                                return
+                            }
+
                             if (mouse.button === Qt.LeftButton) {
                                 if (model.itemType === ItemArrangementProxyModel.FolderItemType) {
                                     root.folderClicked()
@@ -153,12 +172,6 @@ Control {
                                     root.itemClicked()
                                 }
                             } else if (mouse.button === Qt.RightButton) {
-                                root.menuTriggered()
-                            }
-                        }
-                        // touchscreen long press.
-                        onPressAndHold: function (mouse) {
-                            if (mouse.button === Qt.NoButton) {
                                 root.menuTriggered()
                             }
                         }

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -242,7 +242,7 @@ FocusScope {
                     }
                     // touchscreen long press.
                     onPressAndHold: function (mouse) {
-                        if (mouse.button === Qt.NoButton) {
+                        if (mouse.button === Qt.NoButton || mouse.button === Qt.RightButton) {
                             showContextMenu(itemDelegate, model)
                         }
                     }

--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -225,7 +225,20 @@ FocusScope {
                     // 当分类菜单打开时，禁用拖拽功能
                     enabled: !(ddeCategoryMenu.visible || alphabetCategoryPopup.visible)
 
+                    // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
+                    property bool isTouchLongPressed: false
+
+                    TapHandler {
+                        acceptedDevices: PointerDevice.TouchScreen
+                        gesturePolicy: TapHandler.DragThreshold
+                        onLongPressed: {
+                            mouseArea.isTouchLongPressed = true
+                            showContextMenu(itemDelegate, model)
+                        }
+                    }
+
                     onPressed: function (mouse) {
+                        isTouchLongPressed = false
                         if (mouse.button === Qt.LeftButton) {
                             itemDelegate.contentItem.grabToImage(function(result) {
                                 itemDelegate.Drag.imageSource = result.url
@@ -233,17 +246,16 @@ FocusScope {
                         }
                     }
                     onClicked: function (mouse) {
+                        if (isTouchLongPressed) {
+                            isTouchLongPressed = false
+                            return
+                        }
+
                         if (mouse.button === Qt.RightButton) {
                             showContextMenu(itemDelegate, model)
                             baseLayer.focus = true
                         } else {
                             launchApp(desktopId)
-                        }
-                    }
-                    // touchscreen long press.
-                    onPressAndHold: function (mouse) {
-                        if (mouse.button === Qt.NoButton) {
-                            showContextMenu(itemDelegate, model)
                         }
                     }
                 }

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -353,7 +353,7 @@ Item {
 
                     // touchscreen long press.
                     onPressAndHold: function (mouse) {
-                        if (mouse.button === Qt.NoButton) {
+                        if (mouse.button === Qt.NoButton || mouse.button === Qt.RightButton) {
                             showContextMenu(itemDelegate, model, {
                                 hideMoveToTopMenu: index === 0
                             })

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -332,7 +332,23 @@ Item {
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
                     drag.target: itemDelegate
 
+                    // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
+                    property bool isTouchLongPressed: false
+
+                    TapHandler {
+                        acceptedDevices: PointerDevice.TouchScreen
+                        gesturePolicy: TapHandler.DragThreshold
+                        onLongPressed: {
+                            mouseArea.isTouchLongPressed = true
+                            showContextMenu(itemDelegate, model, {
+                                hideMoveToTopMenu: index === 0
+                            })
+                            baseLayer.focus = true
+                        }
+                    }
+
                     onPressed: function (mouse) {
+                        isTouchLongPressed = false
                         if (mouse.button === Qt.LeftButton) {
                             itemDelegate.contentItem.grabToImage(function(result) {
                                 itemDelegate.Drag.imageSource = result.url
@@ -341,6 +357,11 @@ Item {
                     }
 
                     onClicked: function (mouse) {
+                        if (isTouchLongPressed) {
+                            isTouchLongPressed = false
+                            return
+                        }
+
                         if (mouse.button === Qt.RightButton) {
                             showContextMenu(itemDelegate, model, {
                                 hideMoveToTopMenu: index === 0
@@ -348,16 +369,6 @@ Item {
                             baseLayer.focus = true
                         } else {
                             launchItem()
-                        }
-                    }
-
-                    // touchscreen long press.
-                    onPressAndHold: function (mouse) {
-                        if (mouse.button === Qt.NoButton) {
-                            showContextMenu(itemDelegate, model, {
-                                hideMoveToTopMenu: index === 0
-                            })
-                            baseLayer.focus = true
                         }
                     }
                 }

--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -66,7 +66,7 @@ Control {
             }
             // touchscreen long press.
             onPressAndHold: function (mouse) {
-                if (mouse.button === Qt.NoButton) {
+                if (mouse.button === Qt.NoButton || mouse.button === Qt.RightButton) {
                     root.menuTriggered()
                 }
             }

--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -52,7 +52,21 @@ Control {
             acceptedButtons: Qt.LeftButton
             enabled: true
             drag.target: root.dndEnabled ? root : null
+
+            // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
+            property bool isTouchLongPressed: false
+
+            TapHandler {
+                acceptedDevices: PointerDevice.TouchScreen
+                gesturePolicy: TapHandler.DragThreshold
+                onLongPressed: {
+                    mouseArea.isTouchLongPressed = true
+                    root.menuTriggered()
+                }
+            }
+
             onPressed: function (mouse) {
+                isTouchLongPressed = false
                 if (mouse.button === Qt.LeftButton && root.dndEnabled) {
                     appIcon.grabToImage(function(result) {
                         root.Drag.imageSource = result.url;
@@ -60,14 +74,13 @@ Control {
                 }
             }
             onClicked: {
+                if (isTouchLongPressed) {
+                    isTouchLongPressed = false
+                    return
+                }
+
                 if (!drag.active) {
                     root.itemClicked()
-                }
-            }
-            // touchscreen long press.
-            onPressAndHold: function (mouse) {
-                if (mouse.button === Qt.NoButton) {
-                    root.menuTriggered()
                 }
             }
         }


### PR DESCRIPTION
1. Previously, onPressAndHold handlers only triggered when mouse.button was Qt.NoButton
2. Added Qt.RightButton as an additional trigger condition for long press
3. This allows right-click long press to also trigger context menus
4. Applied consistently across all relevant QML files: IconItemDelegate, AppListView, FreeSortListView, and windowed IconItemDelegate

Log: Fixed context menu not opening on right-click long press

Influence:
1. Test right-click long press on icons to verify context menu appears
2. Test regular long press (no button) still works as before
3. Verify no regression for touchscreen long press behavior
4. Test in both normal and windowed mode

fix: 允许右键长按触发上下文菜单

1. 之前 onPressAndHold 处理器仅在 mouse.button 为 Qt.NoButton 时触发
2. 增加了 Qt.RightButton 作为长按的额外触发条件
3. 使右键长按也能触发上下文菜单
4. 在所有相关的 QML 文件中统一应用此修改：IconItemDelegate、 AppListView、FreeSortListView 和窗口模式下的 IconItemDelegate

Log: 修复右键长按时上下文菜单无法打开的问题

Influence:
1. 在图标上测试右键长按，验证上下文菜单是否弹出
2. 测试常规长按（无按钮）是否仍正常工作
3. 验证触控屏长按行为没有回归问题
4. 在普通模式和窗口模式下分别测试

PMS: BUG-358827

## Summary by Sourcery

Bug Fixes:
- Fix context menus not opening when performing a right-click long-press on icons across list and icon delegates in both normal and windowed modes.