### PR TITLE
fix: use dummy drag target on Wayland to prevent layout breakage

### DIFF
--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -329,8 +329,11 @@ Item {
                     id: mouseArea
                     anchors.fill: parent
 
+                    // Use a dummy Item as drag.target so Wayland dnd doesn't break the original ItemDelegate layout
+                    Item { id: dndTarget }
+
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
-                    drag.target: itemDelegate
+                    drag.target: dndTarget
 
                     // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
                     property bool isTouchLongPressed: false


### PR DESCRIPTION
Add a dummy Item as drag.target instead of directly using the ItemDelegate to avoid layout issues in Wayland drag-and-drop. The original implementation caused the ItemDelegate's layout to break when used as a drag target under Wayland compositors, leading to visual glitches and incorrect positioning.

Log: Fix layout breakage during drag-and-drop on Wayland

Influence:
1. Test drag-and-drop functionality in both AppListView and FreeSortListView
2. Verify that item layout remains stable during and after drag operations on Wayland
3. Ensure no regression on X11 sessions
4. Test drag-and-drop behavior with multiple items and across different view sections
5. Verify that right-click context menu still works correctly

fix: 在 Wayland 上使用虚拟拖拽目标以防止布局损坏

添加一个虚拟的 Item 作为 drag.target，而不是直接使用 ItemDelegate，以 避免 Wayland 拖放操作中的布局问题。原实现方式在 Wayland 合成器下直接使
用 ItemDelegate 作为拖拽目标会导致其布局损坏，出现视觉错乱和位置不正确的
问题。

Log: 修复 Wayland 下拖拽时布局损坏问题

Influence:
1. 测试 AppListView 和 FreeSortListView 中的拖拽功能
2. 验证 Wayland 下拖拽操作期间和之后项目布局保持稳定
3. 确保在 X11 会话中没有回归问题
4. 测试多个项目和不同视图区间的拖拽行为
5. 验证右键菜单功能仍然正常工作

此问题修复,自由排序时, 交换应用位置会出现的图标重叠问题.

## Summary by Sourcery

Prevent Wayland drag-and-drop from breaking item layouts by decoupling drag targets from visual delegates in app list views.

Bug Fixes:
- Avoid layout corruption on Wayland by using a dummy drag target instead of the visual ItemDelegate in AppListView and FreeSortListView.

Enhancements:
- Align drag-and-drop behavior in AppListView and FreeSortListView so item layout remains stable across Wayland and X11 sessions.