### PR TITLE
feat: pass launch_type when launching apps from launcher

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
- dde-application-manager (>> 1.2.2),
+ dde-application-manager (>> 1.2.51),
  dde-application-wizard-daemon-compat,
  libdtk6gui(>= 6.0.19),
  libdtk6declarative(>= 6.0.19),

--- a/src/ddeintegration/CMakeLists.txt
+++ b/src/ddeintegration/CMakeLists.txt
@@ -145,3 +145,8 @@ PUBLIC
     Qt::Concurrent
 PRIVATE
     Qt::Core Qt::Gui ${DTK_NS}::Core ${ASQT_NS} launcher-utils)
+
+if (HAVE_DDE_API_EVENTLOGGER)
+    target_compile_definitions(dde-integration-dbus PRIVATE HAVE_DDE_API_EVENTLOGGER)
+    target_link_libraries(dde-integration-dbus PRIVATE DDEAPI::EventLogger)
+endif()

--- a/src/ddeintegration/appmgr.cpp
+++ b/src/ddeintegration/appmgr.cpp
@@ -184,7 +184,11 @@ bool AppMgr::launchApp(const QString &desktopId)
     const auto path = amAppIface->path();
     QProcess process;
     process.setProcessChannelMode(QProcess::MergedChannels);
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    process.start("dde-am", {"--by-user", "--launch-type", "dde-launchpad", path});
+#else
     process.start("dde-am", {"--by-user", path});
+#endif
     if (!process.waitForFinished()) {
         qCWarning(logDdeIntegration) << "Failed to launch the desktopId:" << desktopId << process.errorString();
         return false;


### PR DESCRIPTION
启动器启动应用时传入 launch_type 参数，用于应用启动埋点统计。
launch_type=1 表示从启动器点击启动。

Pass launch_type parameter when launching applications from launcher for application launch event reporting. launch_type=1 indicates the app was launched from the launcher.

PMS: TASK-388657

## Summary by Sourcery

New Features:
- Include a launch_type=1 parameter when invoking dde-am for apps started from the launcher to enable launch analytics.