### PR TITLE
chore: update changelog to 2.0.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-launchpad (2.0.36) unstable; urgency=medium
+
+  * feat: pass launch_type when launching apps from launcher
+
+ -- zhangkun <zhangkun2@uniontech.com>  Sat, 09 May 2026 09:31:25 +0800
+
 dde-launchpad (2.0.35) unstable; urgency=medium
 
   * style: adjust page indicator dot size in fullscreen mode


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.36

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.36
- 目标分支: master
