### PR TITLE
fix: restore right-click context menu in windowed launcher's frequent…

### DIFF
--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -66,16 +66,24 @@ Control {
             }
 
             onPressed: function (mouse) {
+                if (mouse.button !== Qt.LeftButton) {
+                    mouse.accepted = false
+                    return
+                }
                 isTouchLongPressed = false
-                if (mouse.button === Qt.LeftButton && root.dndEnabled) {
+                if (root.dndEnabled) {
                     appIcon.grabToImage(function(result) {
                         root.Drag.imageSource = result.url;
                     })
                 }
             }
-            onClicked: {
+            onClicked: function(mouse) {
                 if (isTouchLongPressed) {
                     isTouchLongPressed = false
+                    return
+                }
+
+                if (mouse.button !== Qt.LeftButton) {
                     return
                 }
 


### PR DESCRIPTION
…ly used view

The TapHandler addition in 957e8a7 caused MouseArea to participate in the pointer event delivery system, which bypassed the acceptedButtons filter and allowed right-click events to be consumed by onClicked, triggering app launch instead of the context menu.

fix: 修复弹窗启动器"常用应用"区域右键菜单失效的问题

957e8a7 提交中新增的 TapHandler 导致 MouseArea 参与指针事件分发系统， 绕过了 acceptedButtons 过滤，右键事件被 onClicked 消费，触发启动应用
而非弹出右键菜单。

PMS: BUG-360855

## Summary by Sourcery

Bug Fixes:
- Prevent right-click events on frequently used app icons in the windowed launcher from being treated as normal clicks that launch the app, allowing the context menu to appear as expected.