### PR TITLE
fix: enforce baseLayer focus when launcher becomes visible

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -887,8 +887,15 @@ InputEventItem {
         Connections {
             target: LauncherController
             function onVisibleChanged() {
-                // only do these clean-up steps on launcher get hide
-                if (LauncherController.visible) return
+                if (LauncherController.visible) {
+                    baseLayer.forceActiveFocus()
+                    Qt.callLater(() => {
+                        if (!baseLayer.activeFocus) {
+                            console.warn("[LaunchpadFocus] FullscreenFrame: BUG_WARNING - baseLayer failed to acquire activeFocus after forceActiveFocus()!")
+                        }
+                    })
+                    return
+                }
                 // clear searchEdit text
                 searchEdit.text = ""
                 if (listviewPage.currentItem) {

--- a/qml/windowed/WindowedFrame.qml
+++ b/qml/windowed/WindowedFrame.qml
@@ -305,8 +305,15 @@ InputEventItem {
     Connections {
         target: LauncherController
         function onVisibleChanged() {
-            // only do these clean-up steps on launcher get hide
-            if (LauncherController.visible) return
+            if (LauncherController.visible) {
+                baseLayer.forceActiveFocus()
+                Qt.callLater(() => {
+                    if (!baseLayer.activeFocus) {
+                        console.warn("[LaunchpadFocus] WindowedFrame: BUG_WARNING - baseLayer failed to acquire activeFocus after forceActiveFocus()!")
+                    }
+                })
+                return
+            }
 
             // clear searchEdit text
             bottomBar.searchEdit.text = ""


### PR DESCRIPTION
To address the low-probability issue where the launcher loses keyboard focus upon opening (preventing direct text input), this commit explicitly calls forceActiveFocus() on the baseLayer (InputEventItem) when LauncherController.visible becomes true.

Unlike previous attempts that focused the searchEdit directly (which violated the design requirement of not activating the search bar visually upon open), this approach ensures the root item safely receives key events and forwards them to the search edit without triggering unwanted visual states.

修复启动器以极低概率打开时丢失键盘焦点（无法直接输入文本）的问题。
在启动器显示（LauncherController.visible 为 true）时，显式调用
baseLayer (InputEventItem) 的 forceActiveFocus() 强制获取活跃焦点。

与之前直接聚焦 searchEdit 的尝试（违背了打开时不直接激活搜索框
的设计要求）不同，此方法确保根节点能安全地接收按键事件并将其转发
给搜索框，同时不会触发不需要的视觉激活状态。

PMS: BUG-301743