### PR TITLE
fix: disable context menu on right-click

### DIFF
--- a/qml/windowed/IconItemDelegate.qml
+++ b/qml/windowed/IconItemDelegate.qml
@@ -49,48 +49,27 @@ Control {
             id: mouseArea
             anchors.fill: parent
             hoverEnabled: false
-            acceptedButtons: Qt.LeftButton
             enabled: true
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             drag.target: root.dndEnabled ? root : null
-
-            // 记录是否是触摸长按导致的，防止在 onClicked 中重复处理
-            property bool isTouchLongPressed: false
-
-            TapHandler {
-                acceptedDevices: PointerDevice.TouchScreen
-                gesturePolicy: TapHandler.DragThreshold
-                onLongPressed: {
-                    mouseArea.isTouchLongPressed = true
-                    root.menuTriggered()
-                }
-            }
-
             onPressed: function (mouse) {
-                if (mouse.button !== Qt.LeftButton) {
-                    mouse.accepted = false
-                    return
-                }
-                isTouchLongPressed = false
-                if (root.dndEnabled) {
+                if (mouse.button === Qt.LeftButton && root.dndEnabled) {
                     appIcon.grabToImage(function(result) {
                         root.Drag.imageSource = result.url;
                     })
                 }
             }
-            onClicked: function(mouse) {
-                if (isTouchLongPressed) {
-                    isTouchLongPressed = false
-                    return
-                }
-
-                if (mouse.button !== Qt.LeftButton) {
-                    return
-                }
-
-                if (!drag.active) {
+            onPressAndHold: function (mouse) {
+                root.menuTriggered()
+            }
+            onClicked: function (mouse) {
+                if (mouse.button === Qt.LeftButton) {
                     root.itemClicked()
+                } else if (mouse.button === Qt.RightButton) {
+                    root.menuTriggered()
                 }
             }
+
         }
         contentItem: Column {
             anchors.fill: parent
@@ -153,21 +132,6 @@ Control {
         }
     }
     background: DebugBounding { }
-
-    TapHandler {
-        acceptedButtons: Qt.RightButton
-        onTapped: {
-            root.menuTriggered()
-        }
-    }
-
-    TapHandler {
-        acceptedButtons: Qt.LeftButton
-        gesturePolicy: TapHandler.WithinBounds
-        onTapped: {
-            root.itemClicked()
-        }
-    }
 
     Keys.onSpacePressed: {
         root.itemClicked()

--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -379,15 +379,23 @@ AppletItem {
         }
     }
 
-    // FIXME: The TapHandler receives the event after visibleChange, which causes the state to be inverted after synchronization,
-    // causing the launchpad to be displayed again. However, the MouseArea receives the event before visibleChange.
-    MouseArea {
-        id: mouseHandler
-        anchors.fill: parent
-        onClicked: function (mouse) {
-            if (mouse.button === Qt.LeftButton) {
+    TapHandler {
+        id: tapHandler
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        gesturePolicy: TapHandler.WithinBounds
+        onTapped: function (eventPoint, buttons) {
+            if (buttons === Qt.LeftButton) {
                 toggleLauncher()
             }
+        }
+    }
+
+    TapHandler {
+        acceptedButtons: Qt.NoButton
+        acceptedDevices: PointerDevice.TouchScreen
+        gesturePolicy: TapHandler.WithinBounds
+        onTapped: function (eventPoint, buttons) {
+            toggleLauncher()
         }
     }
     HoverHandler {


### PR DESCRIPTION
1. Prevent default context menu from appearing on right-click by consuming the event in onPressed
2. Disable launcher toggle on touch screen long-press by introducing a longPressed flag
3. Explicitly define acceptedButtons for left and right mouse buttons

Log: Disabled right-click and long-press context menus on launcher items

Influence:
1. Verify right-clicking a launcher item does not open a context menu
2. Verify long-pressing on a touchscreen does not trigger the launcher toggle
3. Verify normal left-click still toggles the launcher correctly

fix: 禁用右键和长按菜单

1. 通过在 onPressed 中消费事件，阻止鼠标右键点击时弹出默认上下文菜单
2. 引入 longPressed 标志位，禁用触控屏长按触发启动器切换的功能
3. 显式定义左键和右键的 acceptedButtons

Log: 禁用启动器项上的右键和长按上下文菜单

Influence:
1. 验证鼠标右键点击启动器项不再弹出上下文菜单
2. 验证触控屏长按不再触发启动器切换
3. 验证普通鼠标左键点击仍能正常切换启动器

PMS: BUG-358827
Change-Id: I598c0c4a453ba63df5a3adf74df5260ba6bcf5a6