### PR TITLE
chore: update changelog to 2.0.37

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-launchpad (2.0.37) unstable; urgency=medium
+
+  * feat: add Wayland XDG activation token support for app launch
+  * fix: disable context menu on right click
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 20 May 2026 15:16:51 +0800
+
 dde-launchpad (2.0.36) unstable; urgency=medium
 
   * feat: pass launch_type when launching apps from launcher


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.37

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.37
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 2.0.37 in debian changelog.