### PR TITLE
fix: remove modal from app menu

### DIFF
--- a/qml/AppItemMenu.qml
+++ b/qml/AppItemMenu.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -34,7 +34,6 @@ Loader {
             bottomMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.DownArrow ? dockSpacing : 0
             leftMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.LeftArrow ? dockSpacing : 0
             rightMargin: isFullscreen && DesktopIntegration.dockPosition === Qt.RightArrow ? dockSpacing : 0
-            modal: true
 
             // 在全屏模式下，右键菜单适配系统深浅模式
             // 通过设置palette来实现主题适配


### PR DESCRIPTION
Removed the modal property from the AppItemMenu component to allow non-modal behavior. This was necessary to fix an issue where on touch screens, consecutively long-pressing different apps did not permit menus to pop up consecutively, likely due to modal interaction blocking.

Log: Fixed touch screen consecutive menu pop-up issue

Influence:
- Test on touch screens by long-pressing multiple apps in succession to verify menus appear correctly
- Verify that menu functionality works as expected on non-touch devices
- Check for regressions in menu behavior in various scenarios, such as fullscreen mode
- Ensure no negative impact on other UI interactions or system performance

fix: 修复触控屏菜单连续弹出问题

移除了AppItemMenu组件中的modal属性以允许非模态行为。此修改解决了在触控
屏上连续长按不同应用时无法连续弹出菜单的问题，可能是因为模态菜单阻塞了
交互。

Log: 修复触控屏上连续长按无法弹出菜单的问题

Influence:
- 在触控屏上测试连续长按多个应用，验证菜单能正常弹出
- 验证在非触控设备上菜单功能是否按预期工作
- 检查不同场景下菜单行为是否出现回归，如全屏模式
- 确保对其他UI交互或系统性能无负面影响

PMS: BUG-358827
Change-Id: Idc6dac36d6bc5efc6a0093587fd2d1163f8c4819

## Summary by Sourcery

Remove modal behavior from the app item context menu to improve touch-screen interaction and consecutive menu display.

Bug Fixes:
- Resolve an issue where long-pressing multiple apps in succession on touch screens failed to show their menus due to modal blocking.

Enhancements:
- Update AppItemMenu copyright metadata years.