### PR TITLE
chore: update changelog to 2.0.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-launchpad (2.0.38) unstable; urgency=medium
+
+  * fix: remove modal from app menu
+  * fix: enable touch scrolling in launcher
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 28 May 2026 15:42:09 +0800
+
 dde-launchpad (2.0.37) unstable; urgency=medium
 
   * feat: add Wayland XDG activation token support for app launch


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.38

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.38
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 2.0.38 in debian/changelog.