### PR TITLE
fix: launchpad might be blank when starting a new treeland dde session

### DIFF
--- a/src/ddeintegration/appmgr.cpp
+++ b/src/ddeintegration/appmgr.cpp
@@ -132,7 +132,60 @@ AppMgr::AppMgr(QObject *parent)
 {
     m_checkTimer->setInterval(3000); // 3 second interval
     connect(m_checkTimer, &QTimer::timeout, this, &AppMgr::checkPendingAppItems);
-    initObjectManager();
+
+    connect(m_objectManager, &AppManager1ApplicationObjectManager::InterfacesAdded, this,
+            [this](const QDBusObjectPath &objPath, ObjectInterfaceMap interfacesAndProperties) {
+                const QString key(objPath.path());
+                qCDebug(logDdeIntegration) << "InterfacesAdded by AM, path:" << key;
+                if (m_appItems.contains(objPath.path())) {
+                    qWarning() << "App already exists for the path:" << key;
+                    return;
+                }
+                m_checkCount = 0;
+                if (auto appItem = parseDBus2AppItem(interfacesAndProperties)) {
+                    qCDebug(logDdeIntegration) << "App item added, desktopId" << appItem->id;
+                    watchingAppItemAdded(key, appItem);
+                }
+            });
+    connect(m_objectManager, &AppManager1ApplicationObjectManager::InterfacesRemoved, this,
+            [this](const QDBusObjectPath &objPath, const QStringList &interfaces) {
+                Q_UNUSED(interfaces)
+                const QString key(objPath.path());
+                qCDebug(logDdeIntegration) << "InterfacesRemoved by AM, path:" << key;
+                watchingAppItemRemoved(key);
+            });
+
+    DConfig *config = DConfig::create("org.deepin.dde.application-manager", "org.deepin.dde.am", "", this);
+    if (!config->isValid()) {
+        qCWarning(logDdeIntegration) << "DConfig is invalid when getting launched times.";
+    } else {
+        static const QString AppsLaunchedTimes(u8"appsLaunchedTimes");
+        const auto &value = config->value(AppsLaunchedTimes).toMap();
+        updateAppsLaunchedTimes(value);
+        QObject::connect(config, &DConfig::valueChanged, this, [this, config](const QString &key) {
+            if (key != AppsLaunchedTimes) {
+                qCDebug(logDdeIntegration) << "Ignoring non-appsLaunchedTimes key:" << key;
+                return;
+            }
+
+            qCInfo(logDdeIntegration) << "appsLaunchedTimes of DConfig changed, updating";
+            const auto &value = config->value(AppsLaunchedTimes).toMap();
+            updateAppsLaunchedTimes(value);
+        });
+    }
+
+    if (isValid()) {
+        fetchAppItems();
+    }
+
+    m_serviceWatcher = new QDBusServiceWatcher(QStringLiteral("org.desktopspec.ApplicationManager1"),
+                                               QDBusConnection::sessionBus(),
+                                               QDBusServiceWatcher::WatchForRegistration,
+                                               this);
+    connect(m_serviceWatcher, &QDBusServiceWatcher::serviceRegistered, this, [this]() {
+        qCInfo(logDdeIntegration) << "AppManager1 service registered on bus, fetching app items";
+        fetchAppItems();
+    });
 }
 
 AppMgr::~AppMgr()
@@ -427,58 +480,6 @@ void AppMgr::updateAppsLaunchedTimes(const QVariantMap &appsLaunchedTimes)
             item->launchedTimes = times;
             Q_EMIT itemDataChanged(item->id);
         }
-    }
-}
-
-void AppMgr::initObjectManager()
-{
-    if (!isValid()) {
-        qCWarning(logDdeIntegration) << "Object manager is not valid, aborting initialization";
-        return;
-    }
-
-    connect(m_objectManager, &AppManager1ApplicationObjectManager::InterfacesAdded, this,
-            [this](const QDBusObjectPath &objPath, ObjectInterfaceMap interfacesAndProperties) {
-                const QString key(objPath.path());
-                qCDebug(logDdeIntegration) << "InterfacesAdded by AM, path:" << key;
-                if (m_appItems.contains(objPath.path())) {
-                    qWarning() << "App already exists for the path:" << key;
-                    return;
-                }
-                // Reset check count when new app is added
-                m_checkCount = 0;
-                if (auto appItem = parseDBus2AppItem(interfacesAndProperties)) {
-                    qCDebug(logDdeIntegration) << "App item added, desktopId" << appItem->id;
-                    watchingAppItemAdded(key, appItem);
-                }
-            });
-    connect(m_objectManager, &AppManager1ApplicationObjectManager::InterfacesRemoved, this,
-            [this](const QDBusObjectPath &objPath, const QStringList &interfaces) {
-                Q_UNUSED(interfaces)
-                const QString key(objPath.path());
-                qCDebug(logDdeIntegration) << "InterfacesRemoved by AM, path:" << key;
-                watchingAppItemRemoved(key);
-            });
-
-    fetchAppItems();
-
-    DConfig *config = DConfig::create("org.deepin.dde.application-manager", "org.deepin.dde.am", "", this);
-    if (!config->isValid()) {
-        qCWarning(logDdeIntegration) << "DConfig is invalid when getting launched times.";
-    } else {
-        static const QString AppsLaunchedTimes(u8"appsLaunchedTimes");
-        const auto &value = config->value(AppsLaunchedTimes).toMap();
-        updateAppsLaunchedTimes(value);
-        QObject::connect(config, &DConfig::valueChanged, this, [this, config](const QString &key) {
-            if (key != AppsLaunchedTimes) {
-                qCDebug(logDdeIntegration) << "Ignoring non-appsLaunchedTimes key:" << key;
-                return;
-            }
-
-            qCInfo(logDdeIntegration) << "appsLaunchedTimes of DConfig changed, updating";
-            const auto &value = config->value(AppsLaunchedTimes).toMap();
-            updateAppsLaunchedTimes(value);
-        });
     }
 }
 

--- a/src/ddeintegration/appmgr.h
+++ b/src/ddeintegration/appmgr.h
@@ -9,6 +9,7 @@
 #include <QPointer>
 #include <QTimer>
 #include <QFileInfo>
+#include <QDBusServiceWatcher>
 #include <dtkcore_global.h>
 
 DCORE_BEGIN_NAMESPACE
@@ -62,7 +63,6 @@ private slots:
     void checkPendingAppItems();
 
 private:
-    void initObjectManager();
     void fetchAppItems();
     void watchingAppItemAdded(const QString &key, AppMgr::AppItem *appItem);
     void watchingAppItemRemoved(const QString &key);
@@ -72,6 +72,7 @@ private:
 
 private:
     __AppManager1ApplicationObjectManager *m_objectManager;
+    QDBusServiceWatcher *m_serviceWatcher = nullptr;
     QMap<QString, AppMgr::AppItem *> m_appItems;
     QMap<QString, AppMgr::AppItem *> m_pendingAppItems;
     QTimer *m_checkTimer;

--- a/src/models/appsmodel.cpp
+++ b/src/models/appsmodel.cpp
@@ -73,17 +73,15 @@ AppsModel::AppsModel(QObject *parent)
     m_tmUpdateCache->setInterval(1000);
     m_tmUpdateCache->setSingleShot(true);
 
-    if (AppMgr::instance()->isValid()) {
-        connect(AppMgr::instance(), &AppMgr::changed, m_tmUpdateCache, qOverload<>(&QTimer::start));
-        connect(AppMgr::instance(), &AppMgr::itemDataChanged, this, [this](const QString &id) {
-            const auto appItem = this->itemFromDesktopId(id);
-            if (!appItem) {
-                qWarning() << "Not existing item in AppsModel for the desktopId" << id;
-                return;
-            }
-            updateAppItemFromAM(appItem);
-        });
-    }
+    connect(AppMgr::instance(), &AppMgr::changed, m_tmUpdateCache, qOverload<>(&QTimer::start));
+    connect(AppMgr::instance(), &AppMgr::itemDataChanged, this, [this](const QString &id) {
+        const auto appItem = this->itemFromDesktopId(id);
+        if (!appItem) {
+            qWarning() << "Not existing item in AppsModel for the desktopId" << id;
+            return;
+        }
+        updateAppItemFromAM(appItem);
+    });
 
     m_fwIconCache = new DFileWatcherManager(this);
     const QStringList paths = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);


### PR DESCRIPTION
修复treeland dde会话下，启动器应用列表可能完全空白的问题。

Log:

## Summary by Sourcery

Ensure application items and launch statistics are initialized and updated when the DDE application manager service becomes available, preventing empty launchpad app lists in new sessions.

Bug Fixes:
- Prevent the apps model from remaining empty by fetching app items once the ApplicationManager1 D-Bus service registers instead of only during initial construction.
- Avoid missing app updates by always wiring AppsModel signals to AppMgr, regardless of initial AppMgr validity, so late initialization still propagates changes.

Enhancements:
- Refactor AppMgr initialization by inlining object manager and DConfig setup into the constructor and introducing a QDBusServiceWatcher to reactively reload app items when the D-Bus service appears.