### PR TITLE
fix: avoid xdg_activation_v1 destroy on a torn-down display at exit

### DIFF
--- a/src/ddeintegration/xdgactivation.cpp
+++ b/src/ddeintegration/xdgactivation.cpp
@@ -4,7 +4,9 @@
 
 #include "xdgactivation.h"
 
+#include <QCoreApplication>
 #include <QEventLoop>
+#include <QPointer>
 #include <QTimer>
 #include <QWindow>
 #include <QLoggingCategory>
@@ -37,8 +39,16 @@ void XdgActivationTokenV1::xdg_activation_token_v1_done(const QString &token)
 
 XdgActivationV1 *XdgActivationV1::instance()
 {
-    static XdgActivationV1 s_instance;
-    return &s_instance;
+    // Not a function-local static: a static is destroyed at process exit, after
+    // ~QGuiApplication has dropped the Wayland connection, so destroy() in the
+    // destructor would marshal onto a freed wl_proxy and crash. Parent to qApp so
+    // it's torn down with the Qt object tree instead.
+    static QPointer<XdgActivationV1> s_instance;
+    if (!s_instance) {
+        s_instance = new XdgActivationV1;
+        s_instance->setParent(qApp);
+    }
+    return s_instance;
 }
 
 XdgActivationV1::XdgActivationV1()
@@ -48,7 +58,9 @@ XdgActivationV1::XdgActivationV1()
 
 XdgActivationV1::~XdgActivationV1()
 {
-    if (isInitialized())
+    // Runs only at shutdown, when qApp and the Wayland connection may already be
+    // gone; guard so we never send destroy() onto a dead wl_display.
+    if (qApp && isInitialized())
         destroy();
 }
 


### PR DESCRIPTION
## Summary
- `DDEIntegration::XdgActivationV1` was a function-local static (Meyers singleton). Its destructor runs at `__cxa_finalize` — after `main()` returns and `~QGuiApplication` has already torn down the Wayland connection — so `xdg_activation_v1::destroy()` marshals a request onto an already-freed `wl_proxy`/`wl_display` and crashes (`SIGSEGV` in `wl_map_insert_at`).
- Triggered on normal process exit, notably when the session exits during a **VT/TTY switch**.
- Fix: `instance()` now heap-allocates the object and parents it to `qApp` (held via a non-owning `QPointer`) so it is destroyed within Qt's shutdown sequence, not at static-destruction time. The destructor is additionally guarded with `qApp` (which is already null when qApp deletes its children), so `destroy()` is never marshalled onto a dead `wl_display`.

## Crash backtrace (before fix)
```
#0 wl_map_insert_at (data=0x0)
#1 proxy_destroy
#3 wl_proxy_marshal_array_flags
#4 wl_proxy_marshal_flags
#5 QtWayland::xdg_activation_v1::destroy()
#6 DDEIntegration::XdgActivationV1::~XdgActivationV1   (launchpadcommon.so, src/ddeintegration/xdgactivation.cpp)
#7 __cxa_finalize / exit
```

## Test plan
- Run on a treeland/Wayland session; trigger an app-launch activation so the singleton is initialized.
- Switch VT to a text console and back (or otherwise cause the desktop dde-shell process to exit); verify no `dde-shell` coredump in `coredumpctl` with the `xdg_activation_v1::destroy` frame.