### PR TITLE
fix(desktop-integration): open control center via desktop id

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -44,12 +44,8 @@ bool DesktopIntegration::isTreeLand()
 
 void DesktopIntegration::openSystemSettings()
 {
-    DDBusSender()
-        .service("org.deepin.dde.ControlCenter1")
-        .interface("org.deepin.dde.ControlCenter1")
-        .path("/org/deepin/dde/ControlCenter1")
-        .method(QString("Show"))
-        .call();
+    qCInfo(logDesktopIntegration) << "Opening system settings";
+    launchByDesktopId("org.deepin.dde.control-center.desktop");
 }
 
 void DesktopIntegration::launchByDesktopId(const QString &desktopId)


### PR DESCRIPTION
1. Replace D-Bus call to ControlCenter1 with launchByDesktopId
2. Use desktop file ID "org.deepin.dde.control-center.desktop"
3. Add qCInfo log for the open action

Log: Open control center via desktop file ID instead of D-Bus call

fix(desktop-integration): 通过 desktop id 打开控制中心

1. 将 D-Bus 调用 ControlCenter1 替换为 launchByDesktopId
2. 使用 desktop 文件 ID "org.deepin.dde.control-center.desktop"
3. 添加 qCInfo 日志记录打开操作

Log: 通过 desktop 文件 ID 替代 D-Bus 调用打开控制中心
PMS: BUG-365867
Change-Id: I6442fe7f9df1adf275f13b2f6ec12b369608a7fb

## Summary by Sourcery

Open system settings via desktop file ID instead of D-Bus

Bug Fixes:
- Ensure system settings are opened using the desktop file ID rather than a direct D-Bus call

Enhancements:
- Add informational logging when opening system settings via desktop integration