### PR TITLE
fix: fix the issue where multiple applications remain selected after …

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -206,6 +206,12 @@ FocusScope {
                 ColorSelector.pressed: false
                 property Palette textColor: DStyle.Style.button.text
                 palette.windowText: ColorSelector.textColor
+                ColorSelector.hovered: itemHoverHandler.hovered
+
+                HoverHandler {
+                    id: itemHoverHandler
+                }
+
                 ToolTip.text: text
                 ToolTip.delay: 500
                 ToolTip.visible: hovered && contentItem.implicitWidth > contentItem.width
@@ -261,6 +267,8 @@ FocusScope {
                     implicitWidth: DStyle.Style.itemDelegate.width
                     implicitHeight: Helper.windowed.listItemHeight
                     button: itemDelegate
+                    interactionPressed: mouseArea.pressed
+                    interactionHovered: itemHoverHandler.hovered
                 }
             }
             Keys.onReturnPressed: {

--- a/qml/windowed/FreeSortListView.qml
+++ b/qml/windowed/FreeSortListView.qml
@@ -302,6 +302,11 @@ Item {
                 property Palette textColor: DStyle.Style.button.text
                 palette.windowText: ColorSelector.textColor
                 opacity: !Drag.active && (typeof dndItem === "undefined" || dndItem.currentlyDraggedId !== model.desktopId) ? 1 : 0
+                ColorSelector.hovered: itemHoverHandler.hovered
+
+                HoverHandler {
+                    id: itemHoverHandler
+                }
 
                 ToolTip.text: text
                 ToolTip.delay: 500
@@ -323,6 +328,8 @@ Item {
                     implicitWidth: DStyle.Style.itemDelegate.width
                     implicitHeight: Helper.windowed.listItemHeight
                     button: itemDelegate
+                    interactionPressed: mouseArea.pressed
+                    interactionHovered: itemHoverHandler.hovered
                 }
 
                 MouseArea {

--- a/qml/windowed/ItemBackground.qml
+++ b/qml/windowed/ItemBackground.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,8 @@ D.BoxPanel {
     id: control
     property Item button
     property D.Palette background: Helper.itemBackground
+    property bool interactionPressed: control.D.ColorSelector.controlState === D.DTK.PressedState
+    property bool interactionHovered: control.D.ColorSelector.controlState === D.DTK.HoveredState
 
     implicitWidth: DS.Style.toolButton.width
     implicitHeight: DS.Style.toolButton.height
@@ -24,7 +26,7 @@ D.BoxPanel {
         if (typeof dndItem !== "undefined" && dndItem.currentlyDraggedId !== "") {
             return false
         }
-        return button.checked || button.highlighted || button.visualFocus || control.D.ColorSelector.controlState === D.DTK.PressedState || control.D.ColorSelector.controlState === D.DTK.HoveredState
+        return button.checked || button.highlighted || button.visualFocus || interactionPressed || interactionHovered
     }
 
     function selectValue(normal, checked, highlighted) {


### PR DESCRIPTION
…long-pressing the launcher

1. Add interactionPressed and interactionHovered properties to ItemBackground
2. Use HoverHandler for explicit mouse hover detection in list views
3. Replace direct ColorSelector state check with controlled interaction properties
4. Apply consistent interaction state binding in AppListView and FreeSortListView

Log: Fix multiple apps incorrectly staying in selected state after consecutive long presses

fix: 修复启动器长按多个应用后多个应用保持选中状态

1. 为 ItemBackground 添加 interactionPressed 和 interactionHovered 属性
2. 使用 HoverHandler 显式检测鼠标悬停状态
3. 用可控的交互属性替代直接检查 ColorSelector 状态
4. 在 AppListView 和 FreeSortListView 中统一绑定交互状态

Log: 修复启动器长按多个应用后多个应用错误保持选中状态的问题
PMS: BUG-364529

## Summary by Sourcery

Ensure launcher app items update selection state correctly on pointer interactions in windowed views.

Bug Fixes:
- Fix multiple launcher applications remaining selected after consecutive long presses in windowed app and free-sort lists.

Enhancements:
- Add explicit hover handlers and interaction state properties to list item backgrounds to centralize pressed/hovered state handling.