### PR TITLE
fix: prevent app list item overlap after drag on Wayland

### DIFF
--- a/qml/windowed/AppListView.qml
+++ b/qml/windowed/AppListView.qml
@@ -225,9 +225,12 @@ FocusScope {
                 MouseArea {
                     id: mouseArea
                     anchors.fill: parent
+
+                    // Use a dummy Item as drag.target so Wayland dnd doesn't break the original ItemDelegate layout
+                    Item { id: dndTarget }
                     
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
-                    drag.target: itemDelegate
+                    drag.target: dndTarget
                     // 当分类菜单打开时，禁用拖拽功能
                     enabled: !(ddeCategoryMenu.visible || alphabetCategoryPopup.visible)
 


### PR DESCRIPTION
## Summary
- Use an invisible dummy item as the drag target in the categorized app list.
- Keep the visible ItemDelegate under ListView layout control during Wayland drag operations.
- Preserve dock drag-and-drop MIME data for pinning apps to Dock.

## Test plan
- Built successfully with `cmake --build /tmp/dde-launchpad-build`.
- Verified on Wayland/Treeland that dragging items in sort-by-name and sort-by-category modes no longer leaves list items overlapped after release.

Pms: BUG-295171

## Summary by Sourcery

Bug Fixes:
- Resolve item overlap in the categorized app list after drag-and-drop on Wayland by using a separate dummy drag target instead of the visible item delegate.