### PR TITLE
chore: update changelog to 2.0.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-launchpad (2.0.41) unstable; urgency=medium
+
+  * fix: prevent app list item overlap after drag on Wayland
+  * refactor: move XdgActivation to pluginitem and simplify dock plugins
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:17:46 +0800
+
 dde-launchpad (2.0.40) unstable; urgency=medium
 
   * fix: avoid xdg_activation_v1 destroy on a torn-down display at exit


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.41

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.41
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to document version 2.0.41.