### PR TITLE
fix(sidebar): prevent ToolTip on touch tap for sort button

### DIFF
--- a/qml/windowed/SideBar.qml
+++ b/qml/windowed/SideBar.qml
@@ -94,9 +94,13 @@ ColumnLayout {
         KeyNavigation.tab: nextKeyTabTarget
         topPadding: 7
         bottomPadding: 5
-        ToolTip.visible: hovered
+        ToolTip.visible: sortModeHoverHandler.hovered
         ToolTip.delay: 500
         ToolTip.text: qsTr("Sorting Mode")
+
+        HoverHandler {
+            id: sortModeHoverHandler
+        }
 
         contentItem: ColumnLayout {
             spacing: 2


### PR DESCRIPTION
1. Replace implicit hovered with explicit HoverHandler to distinguish touch from hover
2. Fix tooltip popping up on touch screen tap of the sorting mode button
3. Ensure ToolTip only appears on mouse hover, not touch interaction

Log: Fix sorting mode tooltip appearing on touch screen tap by using explicit HoverHandler

fix(sidebar): 修复触控屏点击排序按钮出现提示

1. 使用显式 HoverHandler 区分触摸和悬停事件
2. 修复触控屏点击排序模式按钮时意外弹出 ToolTip 的问题
3. 确保 ToolTip 仅在鼠标悬停时显示，触控操作不触发

Log: 修复触控屏点击排序模式按钮显示 ToolTip 的问题，改用显式 HoverHandler
PMS: BUG-367049