### PR TITLE
chore: update changelog to 2.0.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-launchpad (2.0.42) unstable; urgency=medium
+
+  * fix(sidebar): prevent ToolTip on touch tap for sort button
+  * chore: Sync by
+    https://github.com/linuxdeepin/.github/commit/88706fa723e3771211cb07
+    81d3d97fd4a6cd2a68
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 24 Jun 2026 15:35:11 +0800
+
 dde-launchpad (2.0.41) unstable; urgency=medium
 
   * fix: prevent app list item overlap after drag on Wayland


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.42

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.42
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 2.0.42 in debian/changelog.