### PR TITLE
fix(launcher): remove Qt.Tool flag to fix window stacking

### DIFF
--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -207,7 +207,7 @@ AppletItem {
 
         flags: {
             if (DebugHelper.useRegularWindow) return Qt.Window
-            return (Qt.FramelessWindowHint | Qt.Tool)
+            return Qt.FramelessWindowHint
         }
 
         DWindow.enabled: !DebugHelper.useRegularWindow


### PR DESCRIPTION
Remove Qt.Tool from window flags to prevent QPA from setting
root window as transient parent, which causes stacking order
conflicts with dock popup.

移除 Qt.Tool 标志，避免与 dock popup 窗口排序冲突。

Log: 移除Qt.Tool标志修复窗口排序问题
PMS: BUG-364071
Influence: 移除后launcher窗口不再与dock popup属于同一group，排序恢复正常。

## Summary by Sourcery

Bug Fixes:
- Fix launcher window stacking order conflicts with dock popup windows by removing the Qt.Tool window flag.