### PR TITLE
fix: reset fullscreen app list view position on frame switch

### DIFF
--- a/qml/FullscreenFrame.qml
+++ b/qml/FullscreenFrame.qml
@@ -908,6 +908,7 @@ InputEventItem {
             }
             function onCurrentFrameChanged() {
                 if (LauncherController.currentFrame === "FullscreenFrame") {
+                    listviewPage.changedByNonKeyboard = true
                     listviewPage.setCurrentIndex(0)
                 }
             }


### PR DESCRIPTION
1. When switching back to FullscreenFrame, the app list view now properly resets to the first item
2. Previously, the list view would not reset to the beginning when entering fullscreen mode from other frames
3. Added `changedByNonKeyboard = true` before setting current index to ensure proper state tracking
4. This prevents the list from retaining its previous scroll position, providing consistent user experience

Log: Fixed fullscreen app list view not resetting to the first item when entering fullscreen mode

Influence:
1. Test switching to FullscreenFrame from other frames (launcher, windowed mode)
2. Verify that app list scrolls to the first item on each entry
3. Check that keyboard navigation works correctly after the reset
4. Test with multiple apps installed to ensure scroll position properly resets
5. Verify no regressions in other list view behaviors

fix: 进入全屏模式时重置应用列表视图位置

1. 当切换回FullscreenFrame时，应用列表视图现在会正确重置到第一项
2. 之前从其他框架进入全屏模式时，列表视图不会重置到顶部
3. 在设置当前索引之前添加`changedByNonKeyboard = true`以确保正确的状态 跟踪
4. 这防止了列表保留之前的滚动位置，提供一致的用户体验

Log: 修复进入全屏模式时应用列表视图未重置到第一项的问题

Influence:
1. 测试从其他框架（启动器、窗口模式）切换到FullscreenFrame
2. 验证每次进入时应用列表是否滚动到第一项
3. 检查重置后键盘导航是否正常工作
4. 安装多个应用测试以确保滚动位置正确重置
5. 验证没有影响其他列表视图行为的回归问题

PMS: BUG-366191

## Summary by Sourcery

Bug Fixes:
- Ensure the fullscreen app list view scroll position resets to the first item when entering FullscreenFrame from other frames.