### PR TITLE
feat: add DConfig toggle to enable/disable launchpad

### DIFF
--- a/docs/DConfig.md
+++ b/docs/DConfig.md
@@ -39,6 +39,16 @@ The base configuration template is **usually** located at `/usr/share/dsg/config
 
 ### org.deepin.ds.launchpad
 
+#### `enableLaunchpad`
+
+Controls whether the launchpad is available. Setting it to `false` hides the launchpad entry from the dock, closes an open launchpad, and ignores subsequent show/toggle requests. Changes take effect immediately through DConfig notifications. The default value is `true`.
+
+For example:
+
+```bash
+dde-dconfig set -a org.deepin.dde.shell -r org.deepin.ds.launchpad -k enableLaunchpad -v false
+```
+
 #### `excludeAppIdList` (readonly)
 
 The application id list that shouldn't be displayed in dde-launchpad. The application id is its freedeskop.org [`desktop-entry-spec` desktop file id](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html#desktop-file-id).

--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -15,6 +15,8 @@
 #include <QDBusConnection>
 #include <QLoggingCategory>
 
+#include <DConfig>
+
 #ifdef HAVE_DDE_API_EVENTLOGGER
 #include <dde-api/eventlogger.hpp>
 #endif
@@ -27,6 +29,7 @@ namespace {
 Q_LOGGING_CATEGORY(logController, "org.deepin.dde.launchpad.controller")
 
 constexpr qint64 EVENT_LOGGER_LAUNCHPAD_MODE = 1000610012;
+constexpr auto EnableLaunchpadKey = "enableLaunchpad";
 
 void logLaunchpadMode(const QString &mode, const char *description)
 {
@@ -46,8 +49,24 @@ LauncherController::LauncherController(QObject *parent)
     , optToggle(QStringList{"t", "toggle"}, tr("Toggle launcher visibility"))
     , m_timer(new QTimer(this))
     , m_launcher1Adaptor(new Launcher1Adaptor(this))
+    , m_launchpadConfig(Dtk::Core::DConfig::create(QStringLiteral("org.deepin.dde.shell"),
+                                                   QStringLiteral("org.deepin.ds.launchpad"),
+                                                   QString(),
+                                                   this))
     , m_visible(false)
+    , m_enabled(true)
 {
+    if (m_launchpadConfig) {
+        connect(m_launchpadConfig, &Dtk::Core::DConfig::valueChanged, this, [this](const QString &key) {
+            if (key == QLatin1String(EnableLaunchpadKey)) {
+                updateEnabled();
+            }
+        });
+        updateEnabled();
+    } else {
+        qCWarning(logController) << "Failed to create launchpad DConfig; launchpad remains enabled";
+    }
+
     // TODO: settings should be managed in somewhere else.
     const QString settingBasePath(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
     const QString settingPath(QDir(settingBasePath).absoluteFilePath("settings.ini"));
@@ -141,11 +160,42 @@ bool LauncherController::visible() const
 
 void LauncherController::setVisible(bool visible)
 {
+    if (visible && !m_enabled) {
+        qCDebug(logController) << "Ignoring launchpad show request because it is disabled by DConfig";
+        return;
+    }
+
     if (visible == m_visible) return;
 
     m_visible = visible;
 
     emit visibleChanged(m_visible);
+}
+
+bool LauncherController::enabled() const
+{
+    return m_enabled;
+}
+
+void LauncherController::updateEnabled()
+{
+    if (!m_launchpadConfig->isValid()) {
+        qCWarning(logController) << "Launchpad DConfig is invalid; launchpad remains enabled";
+        return;
+    }
+
+    const bool enabled = m_launchpadConfig->value(QLatin1String(EnableLaunchpadKey), true).toBool();
+    if (enabled == m_enabled) {
+        return;
+    }
+
+    m_enabled = enabled;
+    if (!m_enabled) {
+        setVisible(false);
+    }
+
+    qCInfo(logController) << "Launchpad enabled state changed:" << m_enabled;
+    emit enabledChanged(m_enabled);
 }
 
 bool LauncherController::isFullScreenFrame() const

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,10 @@
 #include <QFont>
 #include <QObject>
 
+namespace Dtk::Core {
+class DConfig;
+}
+
 class QTimer;
 class Launcher1Adaptor;
 class LauncherController : public QObject
@@ -16,6 +20,7 @@ class LauncherController : public QObject
     Q_OBJECT
 
     Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+    Q_PROPERTY(bool enabled READ enabled NOTIFY enabledChanged)
     Q_PROPERTY(QString currentFrame READ currentFrame WRITE setCurrentFrame NOTIFY currentFrameChanged)
     Q_PROPERTY(QString currentScreen READ currentScreen WRITE setCurrentScreen NOTIFY currentScreenChanged)
 
@@ -43,6 +48,7 @@ public:
 
     bool visible() const;
     void setVisible(bool visible);
+    bool enabled() const;
     bool isFullScreenFrame() const;
     QString currentFrame() const;
     void setCurrentFrame(const QString & frame);
@@ -59,6 +65,7 @@ public:
     Q_INVOKABLE void setCurrentFrameToWindowedFrame();
 
 signals:
+    void enabledChanged(bool enabled);
     void currentFrameChanged();
     void currentScreenChanged();
     void visibleChanged(bool visible);
@@ -82,10 +89,13 @@ signals:
 
 private:
     explicit LauncherController(QObject *parent=nullptr);
+    void updateEnabled();
 
     QTimer *m_timer;
     Launcher1Adaptor * m_launcher1Adaptor;
+    Dtk::Core::DConfig *m_launchpadConfig;
     bool m_visible;
+    bool m_enabled;
     QString m_currentFrame;
     QString m_currentScreen;
     bool m_pendingHide = false;

--- a/shell-launcher-applet/package/launcheritem.qml
+++ b/shell-launcher-applet/package/launcheritem.qml
@@ -21,6 +21,7 @@ AppletItem {
     id: launcher
     property bool useColumnLayout: Panel.position % 2
     property int dockOrder: 12
+    property bool shouldVisible: LauncherController.enabled
     // 1:4 the distance between app : dock height; get width/height≈0.8
     implicitWidth: useColumnLayout ? Panel.rootObject.dockSize : Panel.rootObject.dockItemMaxSize * 0.8
     implicitHeight: useColumnLayout ? Panel.rootObject.dockItemMaxSize * 0.8 : Panel.rootObject.dockSize

--- a/src/models/org.deepin.ds.launchpad.json
+++ b/src/models/org.deepin.ds.launchpad.json
@@ -76,6 +76,17 @@
       "permissions": "readwrite",
       "visibility": "private"
     },
+    "enableLaunchpad": {
+      "value": true,
+      "serial": 0,
+      "flags": [],
+      "name": "Enable Launchpad",
+      "name[zh_CN]": "启用启动器",
+      "description": "Show or hide the launchpad entry on the dock and enable or disable launchpad activation.",
+      "description[zh_CN]": "显示或隐藏任务栏上的启动器入口，并启用或禁用启动器唤起。",
+      "permissions": "readwrite",
+      "visibility": "private"
+    },
     "searchByDesktopId": {
       "value": false,
       "serial": 0,


### PR DESCRIPTION
1. Introduce a new `enableLaunchpad` DConfig key under org.deepin.ds.launchpad
2. Read config on startup and react to value changes via DConfig notifications
3. Disabled launchpad hides dock entry, closes open launchpad, and ignores show/toggle requests
4. Add `enabled` property and signal to LauncherController for QML binding
5. Update QML launcheritem to use `shouldVisible` bound to `LauncherController.enabled`
6. Add JSON schema entry for the new config with Chinese translations

Log: Added enableLaunchpad DConfig option to control launchpad availability

Influence:
1. Test setting enableLaunchpad to false when launchpad is open; verify it closes and dock entry hides
2. Test toggle and show requests when disabled; verify they are ignored
3. Test setting enableLaunchpad to true when disabled; verify dock entry reappears and launchpad can be opened
4. Test DConfig value changes are applied immediately via signal
5. Test creating DConfig file scenarios (invalid/missing) and verify enabled state defaults properly
6. Test QML UI reactive update based on `shouldVisible` property
7. Verify no regressions in existing launchpad show/toggle/close behavior

feat: 添加控制启动器开关的DConfig配置项

1. 在 org.deepin.ds.launchpad 下新增 enableLaunchpad DConfig 键
2. 启动时读取配置，并通过 DConfig 通知响应值变化
3. 禁用启动器时隐藏任务栏图标、关闭已打开的启动器、忽略显示/切换请求
4. 为 LauncherController 添加 enabled 属性及其信号，供 QML 绑定
5. 更新 QML launcheritem，将 shouldVisible 绑定到 LauncherController.enabled
6. 新增 JSON schema 配置描述，包含中文翻译

Log: 新增 enableLaunchpad DConfig 选项以控制启动器可用性

Influence:
1. 测试在启动器打开时设置 enableLaunchpad 为 false，验证启动器关闭且任务 栏入口隐藏
2. 测试在禁用状态下发起显示/切换请求，验证请求被忽略
3. 测试在禁用后设置 enableLaunchpad 为 true，验证任务栏入口重新出现且可 打开启动器
4. 测试通过信号实时应用 DConfig 值变化
5. 测试 DConfig 文件异常场景（无效/缺失），验证 enabled 状态的默认处理
6. 测试 QML UI 根据 shouldVisible 属性的响应式更新
7. 验证现有启动器显示/切换/关闭功能无回归

PMS: TASK-393299

## Summary by Sourcery

Add a DConfig-backed switch to control launchpad availability and expose it to QML so the dock entry and launcher behavior react dynamically to configuration changes.

New Features:
- Introduce an `enableLaunchpad` DConfig option under `org.deepin.ds.launchpad` to enable or disable the launchpad at runtime.
- Expose an `enabled` property and signal on `LauncherController` for QML to reflect the launchpad availability in the UI.

Enhancements:
- Update launcher visibility logic to ignore show requests and close the launchpad when it is disabled by configuration.
- Bind the dock launcher item visibility in QML to the new `LauncherController.enabled` property so the dock entry hides when launchpad is disabled.
- Document the new `enableLaunchpad` DConfig key and example usage in the DConfig documentation.