### PR TITLE
fix: handle trash monitor initialization failures and update trash icon

### DIFF
--- a/src/gioutils/trashmonitor.cpp
+++ b/src/gioutils/trashmonitor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,9 +13,19 @@ Q_LOGGING_CATEGORY(logGioUtilsTrash, "org.deepin.dde.launchpad.gioutils.trash")
 TrashMonitor::TrashMonitor(QObject *parent)
     : QObject(parent)
     , m_trash(g_file_new_for_uri("trash:///"))
-    , m_trashMonitor(g_file_monitor_file(m_trash, G_FILE_MONITOR_NONE, NULL, NULL))
+    , m_trashMonitor(nullptr)
 {
     qCDebug(logGioUtilsTrash) << "Initializing TrashMonitor";
+
+    GError *error = nullptr;
+    m_trashMonitor = g_file_monitor_file(m_trash, G_FILE_MONITOR_NONE, nullptr, &error);
+    if (!m_trashMonitor) {
+        qCWarning(logGioUtilsTrash) << "Failed to monitor trash:"
+                                    << (error ? error->message : "unknown error");
+        g_clear_error(&error);
+        return;
+    }
+
     g_signal_connect(m_trashMonitor, "changed", G_CALLBACK(slot_onTrashMonitorChanged), this);
     qCInfo(logGioUtilsTrash) << "TrashMonitor initialized and signal connected";
 }
@@ -23,7 +33,9 @@ TrashMonitor::TrashMonitor(QObject *parent)
 TrashMonitor::~TrashMonitor()
 {
     qCDebug(logGioUtilsTrash) << "Destroying TrashMonitor";
-    g_object_unref(m_trashMonitor);
+    if (m_trashMonitor) {
+        g_object_unref(m_trashMonitor);
+    }
     g_object_unref(m_trash);
 }
 

--- a/src/models/appsmodel.cpp
+++ b/src/models/appsmodel.cpp
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "appsmodel.h"
 #include "categoryutils.h"
 #include "iconutils.h"
+#include "trashmonitor.h"
 
 #include <QDebug>
 #include <QStandardPaths>
@@ -45,6 +46,7 @@ AppsModel::AppsModel(QObject *parent)
     : QStandardItemModel(parent)
     , m_dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"))
     , m_tmUpdateCache(new QTimer(this))
+    , m_trashMonitor(new TrashMonitor(this))
 {
     qCDebug(logModels) << "Initializing AppsModel";
     Q_ASSERT_X(m_dconfig->isValid(), "DConfig", "DConfig file is missing or invalid");
@@ -69,6 +71,8 @@ AppsModel::AppsModel(QObject *parent)
     QList<AppItem *> duplicatedItems = addItems(items);
     Q_ASSERT(duplicatedItems.isEmpty());
     qDebug() << rowCount();
+
+    connect(m_trashMonitor, &TrashMonitor::trashAttributeChanged, this, &AppsModel::updateTrashIcon);
 
     m_tmUpdateCache->setInterval(1000);
     m_tmUpdateCache->setSingleShot(true);
@@ -204,6 +208,25 @@ void AppsModel::updateModelData()
 
     endResetModel();
     qCInfo(logModels) << "Model data updated";
+}
+
+void AppsModel::updateTrashIcon()
+{
+    auto *trashItem = itemFromDesktopId(QStringLiteral("dde-trash.desktop"));
+    if (!trashItem) {
+        qCDebug(logModels) << "Trash item is not present in AppsModel";
+        return;
+    }
+
+    const QString iconName = m_trashMonitor->trashItemCount() > 0
+        ? QStringLiteral("user-trash-full")
+        : QStringLiteral("user-trash");
+    if (trashItem->iconName() == iconName) {
+        return;
+    }
+
+    qCInfo(logModels) << "Updating trash icon to:" << iconName;
+    trashItem->setIconName(iconName);
 }
 
 // the caller manage the return values' ownership (i.e. might need to free them)

--- a/src/models/appsmodel.h
+++ b/src/models/appsmodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,8 @@ namespace Dtk::Core {
 class DConfig;
 class DFileWatcherManager;
 }
+
+class TrashMonitor;
 
 // List of applications and nothing else.
 // Always in a single column so it's a one dimension model.
@@ -60,9 +62,11 @@ private:
 
     QList<AppItem *> allAppInfosShouldBeShown() const;
     void cleanUpInvalidApps(const QList<AppItem *> knownExistedApps);
+    void updateTrashIcon();
 
     Dtk::Core::DConfig * m_dconfig;
     QStringList m_excludedAppIdList;
     Dtk::Core::DFileWatcherManager *m_fwIconCache = nullptr;
     QTimer *m_tmUpdateCache = nullptr;
+    TrashMonitor *m_trashMonitor = nullptr;
 };


### PR DESCRIPTION
1. Enhanced TrashMonitor to properly handle GIO monitor initialization failures with error logging
2. Fixed potential null pointer dereference in destructor by adding null checks
3. Connected trash attribute changes to update the trash icon in AppsModel
4. Added updateTrashIcon method to toggle between empty/full trash icons based on trash item count
5. Updated SPDX copyright headers to 2023-2026

Log: Improved trash icon dynamic updates and error handling for trash monitoring

Influence:
1. Test trash icon updates when adding/removing items from trash
2. Verify trash icon displays correctly when trash is empty vs full
3. Test application launchpad with trash monitor initialization failures
4. Verify no crashes when trash monitor fails to initialize
5. Test icon updates persist across model data refreshes
6. Verify trash icon state matches actual trash contents

fix: 处理回收站监控初始化失败并更新回收站图标

1. 增强 TrashMonitor 对 GIO 监控初始化失败的错误处理和日志记录
2. 在析构函数中添加空指针检查，修复潜在的空指针解引用问题
3. 连接回收站属性变化事件，在 AppsModel 中动态更新回收站图标
4. 添加 updateTrashIcon 方法，根据回收站项目数量切换空/满回收站图标
5. 更新 SPDX 版权头至 2023-2026

Log: 改进了回收站图标的动态更新和回收站监控的错误处理

Influence:
1. 测试向回收站添加/删除项目时图标是否及时更新
2. 验证回收站为空和满时的图标显示是否正确
3. 测试回收站监控初始化失败情况下启动器功能
4. 验证回收站监控初始化失败时不会崩溃
5. 测试图标更新在模型数据刷新后是否保持
6. 验证回收站图标状态与实际回收站内容一致

PMS: BUG-285725

## Summary by Sourcery

Integrate TrashMonitor with AppsModel to keep the trash application icon in sync with actual trash contents, while improving robustness and error handling around trash monitoring and updating license headers.

New Features:
- Add trash monitoring to AppsModel so the trash icon reflects trash contents dynamically.

Bug Fixes:
- Handle GIO trash monitor initialization failures gracefully with error logging and avoid crashes when the monitor cannot be created.
- Prevent potential null pointer dereference in TrashMonitor destructor by guarding the unref call.

Enhancements:
- Update trash icon selection in AppsModel based on trash item count and avoid redundant icon updates.
- Refresh SPDX copyright headers across touched files to cover years 2023–2026.