### PR TITLE
fix: close popups before showing launchpad

### DIFF
--- a/launchercontroller.cpp
+++ b/launchercontroller.cpp
@@ -141,7 +141,29 @@ bool LauncherController::visible() const
 
 void LauncherController::setVisible(bool visible)
 {
-    if (visible == m_visible) return;
+    if (!visible && m_showPending) {
+        m_showPending = false;
+        return;
+    }
+
+    if (visible == m_visible || (visible && m_showPending)) return;
+
+    if (visible && QGuiApplicationPrivate::popupCount() > 0) {
+        m_showPending = true;
+        closeAllPopups();
+
+        // Let Qt finish hiding the current popup and release the Wayland
+        // popup grab before the launcher window is mapped.
+        QTimer::singleShot(0, this, [this] {
+            if (!m_showPending) {
+                return;
+            }
+
+            m_showPending = false;
+            setVisible(true);
+        });
+        return;
+    }
 
     m_visible = visible;
 

--- a/launchercontroller.h
+++ b/launchercontroller.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -86,6 +86,7 @@ private:
     QTimer *m_timer;
     Launcher1Adaptor * m_launcher1Adaptor;
     bool m_visible;
+    bool m_showPending = false;
     QString m_currentFrame;
     QString m_currentScreen;
     bool m_pendingHide = false;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent the launcher from becoming visible while other Qt popups are still active by deferring its display until popups are closed.