### PR TITLE
perf(appstream): reuse metadata pool

### DIFF
--- a/desktopintegration.cpp
+++ b/desktopintegration.cpp
@@ -17,8 +17,6 @@
 
 #include <xdgactivation.h>
 
-#include <AppStreamQt/pool.h>
-
 #include "appwiz.h"
 #include "ddedock.h"
 #include "appearance.h"
@@ -91,38 +89,22 @@ bool DesktopIntegration::appIsCompulsoryForDesktop(const QString &desktopId)
 {
     if (m_compulsoryAppIdList.contains(desktopId)) return true;
 
-#ifdef NO_APPSTREAM_QT
-    Q_UNUSED(desktopId)
-#else
     const QString currentDE(DesktopIntegration::currentDE());
 
-    AppStream::Pool pool;
-    // qDebug() << pool.flags() << currentDE;
-    pool.load();
-
-    const AppStream::ComponentBox components = pool.componentsByLaunchable(AppStream::Launchable::KindDesktopId, desktopId);
+    const AppStream::ComponentBox components = m_appStreamPool.componentsByLaunchable(AppStream::Launchable::KindDesktopId, desktopId);
     for (const AppStream::Component & component : components) {
         return component.compulsoryForDesktops().contains(currentDE);
     }
-#endif
 
     return false;
 }
 
 bool DesktopIntegration::appIsDummyPackage(const QString &desktopId)
 {
-#ifdef NO_APPSTREAM_QT
-    Q_UNUSED(desktopId)
-#else
-    AppStream::Pool pool;
-    // qDebug() << pool.flags();
-    pool.load();
-
-    const AppStream::ComponentBox components = pool.componentsByLaunchable(AppStream::Launchable::KindDesktopId, desktopId);
+    const AppStream::ComponentBox components = m_appStreamPool.componentsByLaunchable(AppStream::Launchable::KindDesktopId, desktopId);
     for (const AppStream::Component & component : components) {
         return component.customValue("DDE::is_dummy_package") == "true";
     }
-#endif
 
     return false;
 }
@@ -232,12 +214,22 @@ void DesktopIntegration::uninstallApp(const QString &desktopId)
 
 DesktopIntegration::DesktopIntegration(QObject *parent)
     : QObject(parent)
+    , m_appStreamPool(this)
     , m_appWizIntegration(new AppWiz(this))
     , m_dockIntegration(new DdeDock(this))
     , m_appearanceIntegration(new Appearance(this))
     , m_iconScaleFactor(1.0)
 {
     qCDebug(logDesktopIntegration) << "Initializing DesktopIntegration";
+    m_appStreamPool.addFlags(AppStream::Pool::FlagMonitor);
+    if (!m_appStreamPool.load()) {
+        qCWarning(logDesktopIntegration) << "Failed to load AppStream metadata:" << m_appStreamPool.lastError();
+    }
+    connect(&m_appStreamPool, &AppStream::Pool::changed, this, [this] {
+        ++m_dummyPackagesRevision;
+        Q_EMIT dummyPackagesChanged();
+    });
+
     QScopedPointer<DConfig> dconfig(DConfig::create("org.deepin.dde.shell", "org.deepin.ds.launchpad"));
     Q_ASSERT_X(dconfig->isValid(), "DConfig", "DConfig file is missing or invalid");
     // TODO:
@@ -266,6 +258,11 @@ DesktopIntegration::DesktopIntegration(QObject *parent)
     connect(m_dockIntegration, &DdeDock::geometryChanged, this, &DesktopIntegration::dockGeometryChanged);
     connect(m_appearanceIntegration, &Appearance::wallpaperBlurhashChanged, this, &DesktopIntegration::backgroundUrlChanged);
     connect(m_appearanceIntegration, &Appearance::opacityChanged, this, &DesktopIntegration::opacityChanged);
+}
+
+uint DesktopIntegration::dummyPackagesRevision() const
+{
+    return m_dummyPackagesRevision;
 }
 
 double DesktopIntegration::scaleFactor() const

--- a/desktopintegration.h
+++ b/desktopintegration.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,6 +8,7 @@
 #include <QRect>
 #include <QStandardPaths>
 #include <QtQml/qqml.h>
+#include <AppStreamQt/pool.h>
 
 class AppWiz;
 class DdeDock;
@@ -23,6 +24,7 @@ class DesktopIntegration : public QObject
     Q_PROPERTY(qreal opacity READ opacity NOTIFY opacityChanged FINAL)
     Q_PROPERTY(double scaleFactor READ scaleFactor NOTIFY scaleFactorChanged FINAL)
     Q_PROPERTY(qreal iconScaleFactor READ iconScaleFactor WRITE setIconScaleFactor NOTIFY iconScaleFactorChanged FINAL)
+    Q_PROPERTY(uint dummyPackagesRevision READ dummyPackagesRevision NOTIFY dummyPackagesChanged FINAL)
 
     QML_NAMED_ELEMENT(DesktopIntegration)
     QML_SINGLETON
@@ -57,6 +59,7 @@ public:
     QRect dockGeometry() const;
     uint dockSpacing() const;
     QString backgroundUrl() const;
+    uint dummyPackagesRevision() const;
 
     Q_INVOKABLE bool isDockedApp(const QString & desktopId) const;
     Q_INVOKABLE void sendToDock(const QString & desktopId);
@@ -81,11 +84,14 @@ signals:
     void opacityChanged();
     void scaleFactorChanged();
     void iconScaleFactorChanged();
+    void dummyPackagesChanged();
 
 private:
     explicit DesktopIntegration(QObject * parent = nullptr);
 
     QStringList m_compulsoryAppIdList;
+    AppStream::Pool m_appStreamPool;
+    uint m_dummyPackagesRevision = 0;
     AppWiz * m_appWizIntegration;
     DdeDock * m_dockIntegration;
     Appearance * m_appearanceIntegration;

--- a/qml/Helper.qml
+++ b/qml/Helper.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,6 +41,8 @@ QtObject {
     }
 
     function generateDragMimeData(desktopId, dockOnly = false) {
+        // Re-evaluate this binding when monitored AppStream metadata changes.
+        DesktopIntegration.dummyPackagesRevision
         // In some cases an app is not allowed to be pinned onto dock via drag-n-drop;
         // We only insert the MIME data for dde-dock in those allowed cases.
         let mime = {}


### PR DESCRIPTION
1. Load AppStream metadata once and reuse the pool for application queries.
2. Monitor metadata changes and notify QML drag MIME bindings.
3. Reuse the pool for compulsory and dummy package checks.

Log: Avoid repeated AppStream metadata loading during launcher item creation
Influence: Reduces launcher display latency.

perf(appstream): 复用元数据池

1. AppStream 元数据仅加载一次，并复用数据池执行应用查询。
2. 监听元数据变化，并通知 QML 重新计算拖拽 MIME 绑定。
3. 必备应用和占位应用检查复用同一个数据池。

Log: 避免创建启动器应用项时重复加载 AppStream 元数据
PMS: TASK-393753
Influence: 降低启动器显示延迟。

## Summary by Sourcery

Reuse a single monitored AppStream metadata pool across desktop integration logic and surface changes to QML for drag MIME recalculation.

New Features:
- Expose a dummyPackagesRevision property from DesktopIntegration to QML to signal AppStream metadata-driven changes.
- Allow QML drag MIME data generation to depend on AppStream metadata updates via the dummyPackagesRevision binding.

Enhancements:
- Initialize and maintain a shared AppStream::Pool instance in DesktopIntegration for all application metadata queries instead of creating per-call pools.
- Enable AppStream metadata monitoring and update internal revision tracking when the pool content changes.

Documentation:
- Update SPDX copyright years in DesktopIntegration and Helper.qml headers.